### PR TITLE
Fix install command in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ cryo can extract the following datasets from EVM nodes:
 ```bash
 git clone https://github.com/paradigmxyz/cryo
 cd cryo
-cargo install --path .
+cargo install --path ./crates/cli
 ```
 
 This method requires having rust installed. See [rustup](https://rustup.rs/) for instructions.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/paradigmxyz/flood/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running ruff and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
```
➜  cryo git:(main) cargo install --path .
error: found a virtual manifest at `/Users/erikreppel/dev/cryo/Cargo.toml` instead of a package manifest
```
Install command in README fails

## Solution

Install the cli directly

```
➜  cryo git:(main) cargo install --path ./crates/cli 
  Installing cryo_cli v0.1.0 (/Users/erikreppel/dev/cryo/crates/cli)
    Updating crates.io index
  Downloaded byte-slice-cast v1.2.2
  Downloaded phf_macros v0.11.2
  Downloaded bytemuck v1.13.1
  ...
  Installing /Users/erikreppel/.cargo/bin/cryo
   Installed package `cryo_cli v0.1.0 (/Users/erikreppel/dev/cryo/crates/cli)` (executable `cryo`)
➜  cryo git:(main) cryo
error: the following required arguments were not provided:
  <DATATYPE>...

Usage: cryo <DATATYPE>...

For more information, try '--help'.
```

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
