### PR TITLE
feat: add `rustfmt.toml`

### DIFF
--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -40,8 +40,8 @@ pub struct Args {
     //     long,
     //     allow_hyphen_values(true),
     //     help_heading = "Content Options",
-    //     help = "Select by data transaction instead of by block,\ncan be a list or a file, see syntax below",
-    // )]
+    //     help = "Select by data transaction instead of by block,\ncan be a list or a file, see
+    // syntax below", )]
     // pub txs: Vec<String>,
     /// Columns to include alongside the default output,
     /// use `all` to include all available columns
@@ -74,12 +74,7 @@ pub struct Args {
     pub network_name: Option<String>,
 
     /// Ratelimit on requests per second
-    #[arg(
-        short('l'),
-        long,
-        value_name = "limit",
-        help_heading = "Acquisition Options"
-    )]
+    #[arg(short('l'), long, value_name = "limit", help_heading = "Acquisition Options")]
     pub requests_per_second: Option<u32>,
 
     /// Global number of concurrent requests
@@ -150,11 +145,7 @@ pub struct Args {
     pub contract: Option<String>,
 
     /// [logs] filter logs by topic0
-    #[arg(
-        long,
-        visible_alias = "event",
-        help_heading = "Dataset-specific Options"
-    )]
+    #[arg(long, visible_alias = "event", help_heading = "Dataset-specific Options")]
     pub topic0: Option<String>,
 
     /// [logs] filter logs by topic1

--- a/crates/cli/src/summaries.rs
+++ b/crates/cli/src/summaries.rs
@@ -5,11 +5,7 @@ use colored::Colorize;
 use std::time::SystemTime;
 use thousands::Separable;
 
-use cryo_freeze::ChunkAgg;
-use cryo_freeze::Datatype;
-use cryo_freeze::FreezeOpts;
-use cryo_freeze::FreezeSummary;
-use cryo_freeze::Table;
+use cryo_freeze::{ChunkAgg, Datatype, FreezeOpts, FreezeSummary, Table};
 
 const TITLE_R: u8 = 0;
 const TITLE_G: u8 = 225;
@@ -17,9 +13,7 @@ const TITLE_B: u8 = 0;
 
 pub(crate) fn print_header<A: AsRef<str>>(header: A) {
     let header_str = header.as_ref().white().bold();
-    let underline = "─"
-        .repeat(header_str.len())
-        .truecolor(TITLE_R, TITLE_G, TITLE_B);
+    let underline = "─".repeat(header_str.len()).truecolor(TITLE_R, TITLE_G, TITLE_B);
     println!("{}", header_str);
     println!("{}", underline);
 }
@@ -45,32 +39,17 @@ pub(crate) fn print_cryo_summary(opts: &FreezeOpts) {
     if let Some(max) = &opts.block_chunks.max_block() {
         print_bullet("max block", max.separate_with_commas());
     };
-    print_bullet(
-        "total blocks",
-        opts.block_chunks.total_blocks().separate_with_commas(),
-    );
+    print_bullet("total blocks", opts.block_chunks.total_blocks().separate_with_commas());
 
     if let Some(first_chunk) = opts.block_chunks.get(0) {
         let chunk_size = first_chunk.total_blocks();
         print_bullet("block chunk size", chunk_size.separate_with_commas());
     };
-    print_bullet(
-        "total block chunks",
-        opts.block_chunks.len().separate_with_commas(),
-    );
-    print_bullet(
-        "max concurrent chunks",
-        opts.max_concurrent_chunks.separate_with_commas(),
-    );
-    print_bullet(
-        "max concurrent blocks",
-        opts.max_concurrent_blocks.separate_with_commas(),
-    );
+    print_bullet("total block chunks", opts.block_chunks.len().separate_with_commas());
+    print_bullet("max concurrent chunks", opts.max_concurrent_chunks.separate_with_commas());
+    print_bullet("max concurrent blocks", opts.max_concurrent_blocks.separate_with_commas());
     if opts.datatypes.contains(&Datatype::Logs) {
-        print_bullet(
-            "log request size",
-            opts.log_opts.log_request_size.to_string(),
-        );
+        print_bullet("log request size", opts.log_opts.log_request_size.to_string());
     };
     print_bullet("output format", opts.output_format.as_str());
     print_bullet("binary column format", opts.binary_column_format.as_str());
@@ -95,11 +74,7 @@ fn print_schema(name: &Datatype, schema: &Table) {
     }
     println!();
     if let Some(sort_cols) = schema.sort_columns.clone() {
-        println!(
-            "sorting {} by: {}",
-            name.dataset().name(),
-            sort_cols.join(", ")
-        );
+        println!("sorting {} by: {}", name.dataset().name(), sort_cols.join(", "));
     } else {
         println!("sorting disabled for {}", name.dataset().name());
     }
@@ -128,7 +103,7 @@ pub(crate) fn print_cryo_conclusion(
         Ok(duration) => duration,
         Err(_e) => {
             println!("error computing system time, aborting");
-            return;
+            return
         }
     };
     let seconds = duration.as_secs();
@@ -137,30 +112,16 @@ pub(crate) fn print_cryo_conclusion(
 
     print_header("collection summary");
     print_bullet("total duration", duration_string);
-    print_bullet(
-        "t_start",
-        dt_start.format("%Y-%m-%d %H:%M:%S%.3f").to_string(),
-    );
+    print_bullet("t_start", dt_start.format("%Y-%m-%d %H:%M:%S%.3f").to_string());
     print_bullet(
         "t_end",
-        "  ".to_string()
-            + dt_data_done
-                .format("%Y-%m-%d %H:%M:%S%.3f")
-                .to_string()
-                .as_str(),
+        "  ".to_string() + dt_data_done.format("%Y-%m-%d %H:%M:%S%.3f").to_string().as_str(),
     );
     let n_chunks = opts.block_chunks.len();
-    print_bullet(
-        "chunks skipped",
-        freeze_summary.n_skipped.separate_with_commas(),
-    );
+    print_bullet("chunks skipped", freeze_summary.n_skipped.separate_with_commas());
     print_bullet(
         "chunks collected",
-        format!(
-            "{} / {}",
-            freeze_summary.n_completed.separate_with_commas(),
-            n_chunks
-        ),
+        format!("{} / {}", freeze_summary.n_completed.separate_with_commas(), n_chunks),
     );
     // let total_blocks = cryo_freeze::get_total_blocks(&opts.block_chunks) as f64;
     let total_blocks = opts.block_chunks.total_blocks() as f64;
@@ -174,14 +135,8 @@ pub(crate) fn print_cryo_conclusion(
     let blocks_per_day = blocks_per_hour * 24.0;
     print_bullet("blocks per second", format_float(blocks_per_second));
     print_bullet("blocks per minute", format_float(blocks_per_minute));
-    print_bullet(
-        "blocks per hour",
-        "  ".to_string() + format_float(blocks_per_hour).as_str(),
-    );
-    print_bullet(
-        "blocks per day",
-        "   ".to_string() + format_float(blocks_per_day).as_str(),
-    );
+    print_bullet("blocks per hour", "  ".to_string() + format_float(blocks_per_hour).as_str());
+    print_bullet("blocks per day", "   ".to_string() + format_float(blocks_per_day).as_str());
 }
 
 fn format_float(number: f64) -> String {

--- a/crates/freeze/src/chunks.rs
+++ b/crates/freeze/src/chunks.rs
@@ -1,7 +1,6 @@
 use ethers::prelude::*;
 
-use crate::types::error_types;
-use crate::types::BlockChunk;
+use crate::types::{error_types, BlockChunk};
 
 /// Aggregation operations related to chunks
 pub trait ChunkAgg {

--- a/crates/freeze/src/dataframes.rs
+++ b/crates/freeze/src/dataframes.rs
@@ -1,7 +1,6 @@
 use polars::prelude::*;
 
-use crate::types::CollectError;
-use crate::types::Table;
+use crate::types::{CollectError, Table};
 
 /// convert a Vec to Series and add to Vec<Series>
 #[macro_export]
@@ -34,9 +33,9 @@ pub(crate) trait SortableDataFrame {
 impl SortableDataFrame for Result<DataFrame, CollectError> {
     fn sort_by_schema(self, schema: &Table) -> Self {
         match (self, &schema.sort_columns) {
-            (Ok(df), Some(sort_columns)) => df
-                .sort(sort_columns, false)
-                .map_err(CollectError::PolarsError),
+            (Ok(df), Some(sort_columns)) => {
+                df.sort(sort_columns, false).map_err(CollectError::PolarsError)
+            }
             (df, _) => df,
         }
     }

--- a/crates/freeze/src/datasets/balance_diffs.rs
+++ b/crates/freeze/src/datasets/balance_diffs.rs
@@ -3,13 +3,9 @@ use std::collections::HashMap;
 use polars::prelude::*;
 
 use super::state_diffs;
-use crate::types::BalanceDiffs;
-use crate::types::BlockChunk;
-use crate::types::CollectError;
-use crate::types::ColumnType;
-use crate::types::Dataset;
-use crate::types::Datatype;
-use crate::types::FreezeOpts;
+use crate::types::{
+    BalanceDiffs, BlockChunk, CollectError, ColumnType, Dataset, Datatype, FreezeOpts,
+};
 
 #[async_trait::async_trait]
 impl Dataset for BalanceDiffs {

--- a/crates/freeze/src/datasets/code_diffs.rs
+++ b/crates/freeze/src/datasets/code_diffs.rs
@@ -3,13 +3,9 @@ use std::collections::HashMap;
 use polars::prelude::*;
 
 use super::state_diffs;
-use crate::types::BlockChunk;
-use crate::types::CodeDiffs;
-use crate::types::CollectError;
-use crate::types::ColumnType;
-use crate::types::Dataset;
-use crate::types::Datatype;
-use crate::types::FreezeOpts;
+use crate::types::{
+    BlockChunk, CodeDiffs, CollectError, ColumnType, Dataset, Datatype, FreezeOpts,
+};
 
 #[async_trait::async_trait]
 impl Dataset for CodeDiffs {

--- a/crates/freeze/src/datasets/logs.rs
+++ b/crates/freeze/src/datasets/logs.rs
@@ -1,26 +1,18 @@
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use ethers::prelude::*;
 use polars::prelude::*;
-use tokio::sync::mpsc;
-use tokio::task;
+use tokio::{sync::mpsc, task};
 
-use crate::chunks::ChunkOps;
-use crate::dataframes::SortableDataFrame;
-use crate::types::conversions::ToVecHex;
-use crate::types::BlockChunk;
-use crate::types::CollectError;
-use crate::types::ColumnType;
-use crate::types::Dataset;
-use crate::types::Datatype;
-use crate::types::FetchOpts;
-use crate::types::FreezeOpts;
-use crate::types::LogOpts;
-use crate::types::Logs;
-use crate::types::Table;
-use crate::with_series;
-use crate::with_series_binary;
+use crate::{
+    chunks::ChunkOps,
+    dataframes::SortableDataFrame,
+    types::{
+        conversions::ToVecHex, BlockChunk, CollectError, ColumnType, Dataset, Datatype, FetchOpts,
+        FreezeOpts, LogOpts, Logs, Table,
+    },
+    with_series, with_series_binary,
+};
 
 #[async_trait::async_trait]
 impl Dataset for Logs {
@@ -99,10 +91,7 @@ async fn fetch_logs(
             if let Some(limiter) = rate_limiter {
                 Arc::clone(&limiter).until_ready().await;
             }
-            let result = provider
-                .get_logs(&filter)
-                .await
-                .map_err(CollectError::ProviderError);
+            let result = provider.get_logs(&filter).await.map_err(CollectError::ProviderError);
             match tx.send(result).await {
                 Ok(_) => {}
                 Err(tokio::sync::mpsc::error::SendError(_e)) => {
@@ -138,7 +127,7 @@ async fn logs_to_df(
             Ok(logs) => {
                 for log in logs.iter() {
                     if let Some(true) = log.removed {
-                        continue;
+                        continue
                     }
                     if let (Some(bn), Some(tx), Some(ti), Some(li)) = (
                         log.block_number,
@@ -180,7 +169,7 @@ async fn logs_to_df(
                                 topic3.push(Some(log.topics[3].as_bytes().to_vec()));
                             }
                             _ => {
-                                return Err(CollectError::InvalidNumberOfTopics);
+                                return Err(CollectError::InvalidNumberOfTopics)
                             }
                         }
                         data.push(log.data.clone().to_vec());
@@ -211,7 +200,5 @@ async fn logs_to_df(
         cols.push(Series::new("chain_id", vec![chain_id; n_rows]));
     }
 
-    DataFrame::new(cols)
-        .map_err(CollectError::PolarsError)
-        .sort_by_schema(schema)
+    DataFrame::new(cols).map_err(CollectError::PolarsError).sort_by_schema(schema)
 }

--- a/crates/freeze/src/datasets/nonce_diffs.rs
+++ b/crates/freeze/src/datasets/nonce_diffs.rs
@@ -3,13 +3,9 @@ use std::collections::HashMap;
 use polars::prelude::*;
 
 use super::state_diffs;
-use crate::types::BlockChunk;
-use crate::types::CollectError;
-use crate::types::ColumnType;
-use crate::types::Dataset;
-use crate::types::Datatype;
-use crate::types::FreezeOpts;
-use crate::types::NonceDiffs;
+use crate::types::{
+    BlockChunk, CollectError, ColumnType, Dataset, Datatype, FreezeOpts, NonceDiffs,
+};
 
 #[async_trait::async_trait]
 impl Dataset for NonceDiffs {

--- a/crates/freeze/src/datasets/state_diffs.rs
+++ b/crates/freeze/src/datasets/state_diffs.rs
@@ -4,18 +4,15 @@ use ethers::prelude::*;
 use polars::prelude::*;
 use tokio::sync::mpsc;
 
-use crate::chunks::ChunkAgg;
-use crate::dataframes::SortableDataFrame;
-use crate::types::conversions::ToVecHex;
-use crate::types::BlockChunk;
-use crate::types::CollectError;
-use crate::types::ColumnType;
-use crate::types::Datatype;
-use crate::types::FetchOpts;
-use crate::types::FreezeOpts;
-use crate::types::Table;
-use crate::with_series;
-use crate::with_series_binary;
+use crate::{
+    chunks::ChunkAgg,
+    dataframes::SortableDataFrame,
+    types::{
+        conversions::ToVecHex, BlockChunk, CollectError, ColumnType, Datatype, FetchOpts,
+        FreezeOpts, Table,
+    },
+    with_series, with_series_binary,
+};
 
 pub(crate) async fn collect_single(
     datatype: &Datatype,

--- a/crates/freeze/src/datasets/storage_diffs.rs
+++ b/crates/freeze/src/datasets/storage_diffs.rs
@@ -3,13 +3,9 @@ use std::collections::HashMap;
 use polars::prelude::*;
 
 use super::state_diffs;
-use crate::types::BlockChunk;
-use crate::types::CollectError;
-use crate::types::ColumnType;
-use crate::types::Dataset;
-use crate::types::Datatype;
-use crate::types::FreezeOpts;
-use crate::types::StorageDiffs;
+use crate::types::{
+    BlockChunk, CollectError, ColumnType, Dataset, Datatype, FreezeOpts, StorageDiffs,
+};
 
 #[async_trait::async_trait]
 impl Dataset for StorageDiffs {

--- a/crates/freeze/src/datasets/traces.rs
+++ b/crates/freeze/src/datasets/traces.rs
@@ -1,25 +1,18 @@
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use ethers::prelude::*;
 use polars::prelude::*;
-use tokio::sync::mpsc;
-use tokio::task;
+use tokio::{sync::mpsc, task};
 
-use crate::chunks::ChunkAgg;
-use crate::dataframes::SortableDataFrame;
-use crate::types::conversions::ToVecHex;
-use crate::types::BlockChunk;
-use crate::types::CollectError;
-use crate::types::ColumnType;
-use crate::types::Dataset;
-use crate::types::Datatype;
-use crate::types::FetchOpts;
-use crate::types::FreezeOpts;
-use crate::types::Table;
-use crate::types::Traces;
-use crate::with_series;
-use crate::with_series_binary;
+use crate::{
+    chunks::ChunkAgg,
+    dataframes::SortableDataFrame,
+    types::{
+        conversions::ToVecHex, BlockChunk, CollectError, ColumnType, Dataset, Datatype, FetchOpts,
+        FreezeOpts, Table, Traces,
+    },
+    with_series, with_series_binary,
+};
 
 #[async_trait::async_trait]
 impl Dataset for Traces {
@@ -83,10 +76,7 @@ impl Dataset for Traces {
     }
 
     fn default_sort(&self) -> Vec<String> {
-        vec![
-            "block_number".to_string(),
-            "transaction_position".to_string(),
-        ]
+        vec!["block_number".to_string(), "transaction_position".to_string()]
     }
 
     async fn collect_chunk(
@@ -223,7 +213,8 @@ async fn traces_to_df(
                         // value: value,
                         // gas: gas,
                         // input: input,
-                        // call_type: action_call_type, [None, Call, CallCode, DelegateCall, StaticCall]
+                        // call_type: action_call_type, [None, Call, CallCode, DelegateCall,
+                        // StaticCall]
                         //
                         // Create
                         // from: from,
@@ -465,7 +456,5 @@ async fn traces_to_df(
         cols.push(Series::new("chain_id", vec![chain_id; n_rows]));
     }
 
-    DataFrame::new(cols)
-        .map_err(CollectError::PolarsError)
-        .sort_by_schema(schema)
+    DataFrame::new(cols).map_err(CollectError::PolarsError).sort_by_schema(schema)
 }

--- a/crates/freeze/src/datasets/vm_traces.rs
+++ b/crates/freeze/src/datasets/vm_traces.rs
@@ -4,21 +4,15 @@ use ethers::prelude::*;
 use polars::prelude::*;
 use tokio::sync::mpsc;
 
-use crate::dataframes::SortableDataFrame;
-use crate::datasets::state_diffs;
-use crate::types::conversions::ToVecHex;
-use crate::types::BlockChunk;
-use crate::types::CollectError;
-use crate::types::ColumnType;
-use crate::types::Dataset;
-use crate::types::Datatype;
-use crate::types::FetchOpts;
-use crate::types::FreezeOpts;
-use crate::types::Table;
-use crate::types::ToVecU8;
-use crate::types::VmTraces;
-use crate::with_series;
-use crate::with_series_binary;
+use crate::{
+    dataframes::SortableDataFrame,
+    datasets::state_diffs,
+    types::{
+        conversions::ToVecHex, BlockChunk, CollectError, ColumnType, Dataset, Datatype, FetchOpts,
+        FreezeOpts, Table, ToVecU8, VmTraces,
+    },
+    with_series, with_series_binary,
+};
 
 #[async_trait::async_trait]
 impl Dataset for VmTraces {
@@ -48,22 +42,11 @@ impl Dataset for VmTraces {
     }
 
     fn default_columns(&self) -> Vec<&'static str> {
-        vec![
-            "block_number",
-            "transaction_position",
-            "pc",
-            "cost",
-            "used",
-            "op",
-        ]
+        vec!["block_number", "transaction_position", "pc", "cost", "used", "op"]
     }
 
     fn default_sort(&self) -> Vec<String> {
-        vec![
-            "block_number".to_string(),
-            "transaction_position".to_string(),
-            "used".to_string(),
-        ]
+        vec!["block_number".to_string(), "transaction_position".to_string(), "used".to_string()]
     }
 
     async fn collect_chunk(
@@ -135,12 +118,7 @@ async fn vm_traces_to_df(
     let mut cols = Vec::new();
 
     with_series!(cols, "block_number", columns.block_number, schema);
-    with_series!(
-        cols,
-        "transaction_position",
-        columns.transaction_position,
-        schema
-    );
+    with_series!(cols, "transaction_position", columns.transaction_position, schema);
     with_series!(cols, "pc", columns.pc, schema);
     with_series!(cols, "cost", columns.cost, schema);
     with_series!(cols, "used", columns.used, schema);
@@ -155,9 +133,7 @@ async fn vm_traces_to_df(
         cols.push(Series::new("chain_id", vec![chain_id; columns.n_rows]));
     };
 
-    DataFrame::new(cols)
-        .map_err(CollectError::PolarsError)
-        .sort_by_schema(schema)
+    DataFrame::new(cols).map_err(CollectError::PolarsError).sort_by_schema(schema)
 }
 
 fn add_ops(

--- a/crates/freeze/src/lib.rs
+++ b/crates/freeze/src/lib.rs
@@ -17,7 +17,6 @@ mod freeze;
 mod outputs;
 mod types;
 
-pub use chunks::ChunkAgg;
-pub use chunks::ChunkOps;
+pub use chunks::{ChunkAgg, ChunkOps};
 pub use freeze::freeze;
 pub use types::*;

--- a/crates/freeze/src/outputs.rs
+++ b/crates/freeze/src/outputs.rs
@@ -1,8 +1,9 @@
 use polars::prelude::*;
 
-use crate::chunks::ChunkOps;
-use crate::types::FileError;
-use crate::types::{BlockChunk, FreezeOpts};
+use crate::{
+    chunks::ChunkOps,
+    types::{BlockChunk, FileError, FreezeOpts},
+};
 
 /// get file path of output chunk
 pub(crate) fn get_chunk_path(

--- a/crates/freeze/src/types/cli_types.rs
+++ b/crates/freeze/src/types/cli_types.rs
@@ -1,17 +1,11 @@
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use ethers::prelude::*;
 use polars::prelude::*;
 
-use crate::types::BlockChunk;
-use crate::types::ColumnEncoding;
-use crate::types::Datatype;
-use crate::types::FetchOpts;
-use crate::types::FileFormat;
-use crate::types::LogOpts;
-use crate::types::RateLimiter;
-use crate::types::Table;
+use crate::types::{
+    BlockChunk, ColumnEncoding, Datatype, FetchOpts, FileFormat, LogOpts, RateLimiter, Table,
+};
 
 /// Options controling the behavior of a freeze operation
 #[derive(Clone)]
@@ -65,9 +59,7 @@ pub struct FreezeOpts {
 impl FreezeOpts {
     /// create FetchOpts for an individual chunk
     pub fn chunk_fetch_opts(&self) -> FetchOpts {
-        let sem = Arc::new(tokio::sync::Semaphore::new(
-            self.max_concurrent_blocks as usize,
-        ));
+        let sem = Arc::new(tokio::sync::Semaphore::new(self.max_concurrent_blocks as usize));
         FetchOpts {
             // provider: self.provider.clone(),
             provider: Arc::clone(&self.provider),

--- a/crates/freeze/src/types/conversions.rs
+++ b/crates/freeze/src/types/conversions.rs
@@ -61,8 +61,6 @@ impl ToVecHex for Vec<Option<Vec<u8>>> {
     type Output = Vec<Option<String>>;
 
     fn to_vec_hex(&self) -> Self::Output {
-        self.iter()
-            .map(|opt| opt.as_ref().map(|v| prefix_hex::encode(v.clone())))
-            .collect()
+        self.iter().map(|opt| opt.as_ref().map(|v| prefix_hex::encode(v.clone()))).collect()
     }
 }

--- a/crates/freeze/src/types/data_types.rs
+++ b/crates/freeze/src/types/data_types.rs
@@ -5,10 +5,7 @@ use std::collections::HashMap;
 use async_trait;
 use polars::prelude::*;
 
-use crate::types::error_types;
-use crate::types::BlockChunk;
-use crate::types::ColumnType;
-use crate::types::FreezeOpts;
+use crate::types::{error_types, BlockChunk, ColumnType, FreezeOpts};
 
 /// Balance Diffs Dataset
 pub struct BalanceDiffs;
@@ -94,11 +91,8 @@ pub trait Dataset: Sync + Send {
     //     block_chunk: &BlockChunk,
     //     extras: &HashSet<Datatype>,
     //     opts: &FreezeOpts,
-    // ) -> HashMap<Datatype, DataFrame> {
-    //     if !extras.is_empty() {
-    //         ...
-    //     }
-    //     let df = self.collect_chunk(block_chunk, opts).await;
-    //     [(self.datatype(), df)].iter().cloned().collect()
+    // ) -> HashMap<Datatype, DataFrame> { if !extras.is_empty() { ... } let df =
+    //   self.collect_chunk(block_chunk, opts).await; [(self.datatype(),
+    //   df)].iter().cloned().collect()
     // }
 }

--- a/crates/freeze/src/types/external_types.rs
+++ b/crates/freeze/src/types/external_types.rs
@@ -1,8 +1,9 @@
 /// aliases for external types
 use governor::clock::DefaultClock;
-use governor::middleware::NoOpMiddleware;
-use governor::state::direct::NotKeyed;
-use governor::state::InMemoryState;
+use governor::{
+    middleware::NoOpMiddleware,
+    state::{direct::NotKeyed, InMemoryState},
+};
 
 /// RateLimiter based on governor crate
 pub type RateLimiter = governor::RateLimiter<NotKeyed, InMemoryState, DefaultClock, NoOpMiddleware>;

--- a/crates/freeze/src/types/mod.rs
+++ b/crates/freeze/src/types/mod.rs
@@ -17,21 +17,12 @@ pub mod output_types;
 /// type specifications for data schemas
 pub mod schema_types;
 
-pub use cli_types::FreezeChunkSummary;
-pub use cli_types::FreezeOpts;
-pub use cli_types::FreezeSummary;
-pub use conversions::ToVecHex;
-pub use conversions::ToVecU8;
+pub use cli_types::{FreezeChunkSummary, FreezeOpts, FreezeSummary};
+pub use conversions::{ToVecHex, ToVecU8};
 pub use data_types::*;
 pub use external_types::RateLimiter;
-pub use fetch_types::FetchOpts;
-pub use fetch_types::LogOpts;
-pub use output_types::BlockChunk;
-pub use output_types::ColumnEncoding;
-pub use output_types::FileFormat;
-pub use schema_types::ColumnType;
-pub use schema_types::Table;
+pub use fetch_types::{FetchOpts, LogOpts};
+pub use output_types::{BlockChunk, ColumnEncoding, FileFormat};
+pub use schema_types::{ColumnType, Table};
 
-pub use error_types::CollectError;
-pub use error_types::FileError;
-pub use error_types::FreezeError;
+pub use error_types::{CollectError, FileError, FreezeError};

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,9 @@
+reorder_imports = true
+imports_granularity = "Crate"
+use_small_heuristics = "Max"
+comment_width = 100
+wrap_comments = true
+binop_separator = "Back"
+trailing_comma = "Vertical"
+trailing_semicolon = false
+use_field_init_shorthand = true


### PR DESCRIPTION
Introduces the same rustfmt settings as we use in Foundry, Reth, and Alloy, and formats the code.

This config features some nice things like comment formatting, import "merging", and import reodering.