### PR TITLE
Surface RPC error in trace

### DIFF
--- a/crates/freeze/src/datasets/traces.rs
+++ b/crates/freeze/src/datasets/traces.rs
@@ -429,7 +429,7 @@ async fn traces_to_df(
                     }
                 }
             }
-            _ => return Err(CollectError::TooManyRequestsError),
+            Err(e) => return Err(CollectError::RPCError(e.to_string())),
         }
     }
 

--- a/crates/freeze/src/types/errors.rs
+++ b/crates/freeze/src/types/errors.rs
@@ -53,6 +53,10 @@ pub enum CollectError {
     /// Error related to too many requests
     #[error("try using a rate limit with --requests-per-second or limiting max concurrency with --max-concurrent-requests")]
     TooManyRequestsError,
+
+    /// Generic RPC Error
+    #[error("RPC call error")]
+    RPCError(String),
 }
 
 /// Error related to parsing


### PR DESCRIPTION
Rather than assuming a rate limit error, return the error message from the RPC node

This far from perfect as it doesn't account for other error cases. Ideally we could pattern match to find the exact error case but different RPC providers return diff error formats. But I think this is potentially more helpful when debugging dataset requests

ex.

Alchemy
![Screen Shot 2023-08-01 at 2 59 01 PM](https://github.com/paradigmxyz/cryo/assets/4401444/c4328c0c-5be3-479d-847e-ac8548090133)

RETH with traces disabled
![Screen Shot 2023-08-01 at 2 58 42 PM](https://github.com/paradigmxyz/cryo/assets/4401444/97fddaef-cdcf-4eef-97fb-39d4bfe1fe49)

Before this PR:

![Screen Shot 2023-08-01 at 3 04 04 PM](https://github.com/paradigmxyz/cryo/assets/4401444/bdc98db8-68a2-4928-b3b9-ab499aa848db)


TODOs
- [ ] Add similar error handling to other dataset files