### PR TITLE
Fix/rpcparseerror

### DIFF
--- a/crates/cli/src/parse/source.rs
+++ b/crates/cli/src/parse/source.rs
@@ -14,11 +14,7 @@ pub(crate) async fn parse_source(args: &Args) -> Result<Source, ParseError> {
     let rpc_url = parse_rpc_url(args);
     let provider = Provider::<Http>::try_from(rpc_url)
         .map_err(|_e| ParseError::ParseError("could not connect to provider".to_string()))?;
-    let chain_id = provider
-        .get_chainid()
-        .await
-        .map_err(|e| ParseError::ProviderError(e))?
-        .as_u64();
+    let chain_id = provider.get_chainid().await.map_err(|e| ParseError::ProviderError(e))?.as_u64();
 
     let rate_limiter = match args.requests_per_second {
         Some(rate_limit) => match NonZeroU32::new(rate_limit) {

--- a/crates/cli/src/parse/source.rs
+++ b/crates/cli/src/parse/source.rs
@@ -17,7 +17,7 @@ pub(crate) async fn parse_source(args: &Args) -> Result<Source, ParseError> {
     let chain_id = provider
         .get_chainid()
         .await
-        .map_err(|_e| ParseError::ParseError("could not connect to provider".to_string()))?
+        .map_err(|e| ParseError::ProviderError(e))?
         .as_u64();
 
     let rate_limiter = match args.requests_per_second {

--- a/crates/freeze/src/types/errors.rs
+++ b/crates/freeze/src/types/errors.rs
@@ -70,6 +70,10 @@ pub enum ParseError {
     #[error("Parsing error")]
     ParseError(String),
 
+    /// Error related to provider operations
+    #[error("Failed to get block: {0}")]
+    ProviderError(#[source] ProviderError),
+
     /// Parse int error
     #[error("Parsing error")]
     ParseIntError(#[from] std::num::ParseIntError),


### PR DESCRIPTION
Errors during RPC connection attempt on parse were getting hidden by Parse errors. This PR adds ability for provider errors to surface

Before this PR (with invalid RPC)
![Screen Shot 2023-08-07 at 3 06 00 PM](https://github.com/paradigmxyz/cryo/assets/4401444/e162648a-ba72-482f-bed9-0b2b56d0e8d8)

After this PR (with invalid RPC)
![Screen Shot 2023-08-07 at 2 55 28 PM](https://github.com/paradigmxyz/cryo/assets/4401444/5631c91e-b3ea-4d6c-be3d-f0800705bb27)
