### PR TITLE
Better error propagation / display.

### DIFF
--- a/crates/freeze/src/types/errors.rs
+++ b/crates/freeze/src/types/errors.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum FreezeError {
     /// Error related to processing file path
-    #[error("Failed to create file path")]
+    #[error(transparent)]
     FilePathError(#[from] FileError),
 
     /// Error related to joining a tokio task
@@ -15,7 +15,7 @@ pub enum FreezeError {
     TaskFailed(#[source] tokio::task::JoinError),
 
     /// Error related to collecting data
-    #[error("Collect error")]
+    #[error(transparent)]
     CollectError(#[from] CollectError),
 
     /// Error related to progress bar
@@ -23,7 +23,7 @@ pub enum FreezeError {
     ProgressBarError(#[from] indicatif::style::TemplateError),
 
     /// Parse error
-    #[error("Parsing error")]
+    #[error(transparent)]
     ParseError(#[from] ParseError),
 
     /// Error from serializing report
@@ -79,7 +79,7 @@ pub enum CollectError {
 #[derive(Error, Debug)]
 pub enum ParseError {
     /// Error related to parsing
-    #[error("Parsing error")]
+    #[error("Parsing error {0:?}")]
     ParseError(String),
 
     /// Error related to provider operations


### PR DESCRIPTION
## Motivation
Errors are often very opaque, e.g. "Parse error" even when there was specific IO or logic error causing it underneath.

## Solution
Make some of the errors `transparent` or include inner error message in the final error

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [none] Breaking changes
