### PR TITLE
Return error from main when some chunks failed.

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -15,7 +15,8 @@ use eyre::Result;
 async fn main() -> Result<()> {
     let args = Args::parse();
     match run::run(args).await {
-        Ok(Some(_freeze_summary)) => Ok(()),
+        Ok(Some(freeze_summary)) if freeze_summary.n_errored == 0 => Ok(()),
+        Ok(Some(_freeze_summary)) => Err(eyre::Error::msg("Some chunks failed")),
         Ok(None) => Ok(()),
         Err(e) => Err(eyre::Report::from(e)),
     }


### PR DESCRIPTION
## Motivation
When some chunk collection fails the `cryo` command happily returns success code and tooling can't notice failures

## Solution
Return `Err` from main when some chunk failed

## PR Checklist

-   [not applicable ] Added Tests
-   [not applicable ] Added Documentation
-   [command previously succeeded when there were errors, now it's not ] Breaking changes
