### PR TITLE
More permissive include/exclude column specifier interpretation.

### DIFF
--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -39,8 +39,10 @@ pub struct Args {
     )]
     pub reorg_buffer: u64,
 
-    /// Columns to include alongside the defaults,
-    /// use `all` to include all available columns
+    /// Columns to include alongside the default output,
+    /// use `all` to include all available columns.
+    /// Unknown columns are ignored per dataset, so a superset of columns can be specified for
+    /// multiset download.
     #[arg(short, long, value_name="COLS", num_args(0..), verbatim_doc_comment, help_heading="Content Options")]
     pub include_columns: Option<Vec<String>>,
 


### PR DESCRIPTION
## Motivation
When fetching multiple dataset including some non-default columns it might be necessary to specify `--include_columns` value that is only present in one of the data-sets. Currently this fails as the code requires included columns to exist for each evaluated dataset.

## Solution
Make `--include_columns` and `--exclude_columns` filter their values against existing columns for each data-set. This way the configuration is more permissive (non-existing columns specified in them are ignored), but also allows above use-case, which is currently not supported.

## PR Checklist

-   [ yes] Added Tests
-   [ yes] Added Documentation
-   [ non-existing include/exclude columns are silently ignored instead of failing the command] Breaking changes
