### PR TITLE
fix(u256) hex output check for u256 series generation.

### DIFF
--- a/crates/freeze/src/datasets/transactions.rs
+++ b/crates/freeze/src/datasets/transactions.rs
@@ -9,8 +9,8 @@ use crate::{
     dataframes::SortableDataFrame,
     types::{
         conversions::{ToVecHex, ToVecU8},
-        BlockChunk, CollectError, ColumnType, Dataset, Datatype, RowFilter, Source, Table,
-        TransactionChunk, Transactions, U256Type,
+        BlockChunk, CollectError, ColumnEncoding, ColumnType, Dataset, Datatype, RowFilter, Source,
+        Table, TransactionChunk, Transactions, U256Type,
     },
     with_series, with_series_binary, with_series_u256,
 };

--- a/crates/freeze/src/types/dataframes/creation.rs
+++ b/crates/freeze/src/types/dataframes/creation.rs
@@ -33,7 +33,7 @@ macro_rules! with_series_u256 {
                 let name = name.as_str();
 
                 let converted: Vec<Vec<u8>> = $value.iter().map(|v| v.to_vec_u8()).collect();
-                if let Some(ColumnType::Hex) = $schema.column_type($name) {
+                if ColumnEncoding::Hex == $schema.binary_type {
                     $all_series.push(Series::new(name, converted.to_vec_hex()));
                 } else {
                     $all_series.push(Series::new(name, converted));


### PR DESCRIPTION
## Motivation
Fixes https://github.com/paradigmxyz/cryo/issues/55

## Solution
Since `column_type` returns `U256` now, the check for hex should be against the global column encoding instead of column type.

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ none ] Breaking changes
