### PR TITLE
fix: update gas_limit variable type from u32 to u64

### DIFF
--- a/crates/freeze/src/datasets/transactions.rs
+++ b/crates/freeze/src/datasets/transactions.rs
@@ -35,7 +35,7 @@ impl Dataset for Transactions {
             ("to_address", ColumnType::Binary),
             ("value", ColumnType::UInt256),
             ("input", ColumnType::Binary),
-            ("gas_limit", ColumnType::UInt32),
+            ("gas_limit", ColumnType::UInt64),
             ("gas_used", ColumnType::UInt32),
             ("gas_price", ColumnType::UInt64),
             ("transaction_type", ColumnType::UInt32),
@@ -173,7 +173,7 @@ pub(crate) struct TransactionColumns {
     to_address: Vec<Option<Vec<u8>>>,
     value: Vec<U256>,
     input: Vec<Vec<u8>>,
-    gas_limit: Vec<u32>,
+    gas_limit: Vec<u64>,
     gas_used: Vec<u32>,
     gas_price: Vec<Option<u64>>,
     transaction_type: Vec<Option<u32>>,
@@ -250,7 +250,7 @@ impl TransactionColumns {
             self.input.push(tx.input.to_vec());
         }
         if schema.has_column("gas_limit") {
-            self.gas_limit.push(tx.gas.as_u32());
+            self.gas_limit.push(tx.gas.as_u64());
         }
         if schema.has_column("gas_used") {
             self.gas_used.push(gas_used.unwrap())


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/paradigmxyz/flood/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running ruff and building the
documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
When collecting transactions data from other EVM chains (BSC) there were some transactions that had a gas_limit greater than u32::MAX() which caused an integer overflow error.

In BSC there are transactions that use i64::MAX as the gas limit. This is most commonly seen in the last transaction of the block where the validator deposits to the validator set.

Example here: https://bscscan.com/tx/0x7dcda3c9b1ced4c01f5634a88ab72a34ffc3d3f4c1fe1aed88c2fca0d0a34efd

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Update data type for gas_limit variable  for transactions from u32 to u64.

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
