### PR TITLE
fallback to multiple `eth_getTransactionReceipt` calls if `eth_getBlockReceipts` is not present

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Standard types across tables:
 |dataset|blocks per request|results per block|method|
 |-|-|-|-|
 |Blocks|1|1|`eth_getBlockByNumber`|
-|Transactions|1|multiple|`eth_getBlockByNumber`|
+|Transactions|1|multiple|`eth_getBlockByNumber`, `eth_getBlockReceipts`, `eth_getTransactionReceipt`|
 |Logs|multiple|multiple|`eth_getLogs`|
 |Contracts|1|multiple|`trace_block`|
 |Traces|1|multiple|`trace_block`|

--- a/crates/freeze/src/datasets/transactions.rs
+++ b/crates/freeze/src/datasets/transactions.rs
@@ -1,4 +1,4 @@
-use crate::*;
+use crate::{sources::FetcherExt, *};
 use ethers::prelude::*;
 use polars::prelude::*;
 
@@ -44,7 +44,8 @@ impl CollectByBlock for Transactions {
             .ok_or(CollectError::CollectError("block not found".to_string()))?;
         let schema = query.schemas.get_schema(&Datatype::Transactions)?;
         let receipt = if schema.has_column("gas_used") | schema.has_column("success") {
-            Some(source.fetcher.get_block_receipts(request.block_number()?).await?)
+            // Some(source.fetcher.get_block_receipts(request.block_number()?).await?)
+            Some(source.fetcher.get_tx_receipts_in_block(&block).await?)
         } else {
             None
         };

--- a/crates/freeze/src/datasets/transactions.rs
+++ b/crates/freeze/src/datasets/transactions.rs
@@ -1,4 +1,4 @@
-use crate::{sources::FetcherExt, *};
+use crate::*;
 use ethers::prelude::*;
 use polars::prelude::*;
 
@@ -44,7 +44,7 @@ impl CollectByBlock for Transactions {
             .ok_or(CollectError::CollectError("block not found".to_string()))?;
         let schema = query.schemas.get_schema(&Datatype::Transactions)?;
         let receipt = if schema.has_column("gas_used") | schema.has_column("success") {
-            Some(source.fetcher.get_tx_receipts_in_block(&block).await?)
+            Some(source.get_tx_receipts_in_block(&block).await?)
         } else {
             None
         };

--- a/crates/freeze/src/datasets/transactions.rs
+++ b/crates/freeze/src/datasets/transactions.rs
@@ -44,7 +44,6 @@ impl CollectByBlock for Transactions {
             .ok_or(CollectError::CollectError("block not found".to_string()))?;
         let schema = query.schemas.get_schema(&Datatype::Transactions)?;
         let receipt = if schema.has_column("gas_used") | schema.has_column("success") {
-            // Some(source.fetcher.get_block_receipts(request.block_number()?).await?)
             Some(source.fetcher.get_tx_receipts_in_block(&block).await?)
         } else {
             None

--- a/crates/freeze/src/types/sources.rs
+++ b/crates/freeze/src/types/sources.rs
@@ -6,7 +6,10 @@ use governor::{
     middleware::NoOpMiddleware,
     state::{direct::NotKeyed, InMemoryState},
 };
-use tokio::sync::{AcquireError, Semaphore, SemaphorePermit};
+use tokio::{
+    sync::{AcquireError, Semaphore, SemaphorePermit},
+    task,
+};
 
 use crate::CollectError;
 
@@ -185,6 +188,9 @@ impl<P: JsonRpcClient> Fetcher<P> {
     }
 
     /// Returns all receipts for a block.
+    /// Note that this uses the `eth_getBlockReceipts` method which is not supported by all nodes.
+    /// Consider using `FetcherExt::get_tx_receipts_in_block` which takes a block, and falls back to
+    /// `eth_getTransactionReceipt` if `eth_getBlockReceipts` is not supported.
     pub async fn get_block_receipts(&self, block_num: u64) -> Result<Vec<TransactionReceipt>> {
         let _permit = self.permit_request().await;
         Self::map_err(self.provider.get_block_receipts(block_num).await)
@@ -549,9 +555,60 @@ impl<P: JsonRpcClient> Fetcher<P> {
     }
 }
 
+/// Extension methods for `Fetcher<Provider<P>>` that requires single `Fetcher` instance to make
+/// multiple RPC calls concurrently
+#[async_trait::async_trait]
+pub trait FetcherExt {
+    /// Returns all receipts for a block.
+    /// Tries to use `eth_getBlockReceipts` first, and falls back to `eth_getTransactionReceipt`
+    async fn get_tx_receipts_in_block(
+        &self,
+        block: &Block<Transaction>,
+    ) -> Result<Vec<TransactionReceipt>>;
+}
+
+#[async_trait::async_trait]
+impl<P: JsonRpcClient + 'static> FetcherExt for Arc<Fetcher<P>> {
+    async fn get_tx_receipts_in_block(
+        &self,
+        block: &Block<Transaction>,
+    ) -> Result<Vec<TransactionReceipt>> {
+        let block_number =
+            block.number.ok_or(CollectError::CollectError("no block number".to_string()))?.as_u64();
+        match self.get_block_receipts(block_number).await {
+            Ok(receipts) => return Ok(receipts),
+            Err(_) => (),
+        };
+
+        // fallback to `eth_getTransactionReceipt`
+        let mut tasks = Vec::new();
+        for tx in &block.transactions {
+            let tx_hash = tx.hash;
+            let self_clone = self.clone();
+            let task = task::spawn(async move {
+                match self_clone.get_transaction_receipt(tx_hash).await? {
+                    Some(receipt) => Ok(receipt),
+                    None => {
+                        Err(CollectError::CollectError("could not find tx receipt".to_string()))
+                    }
+                }
+            });
+            tasks.push(task);
+        }
+        let mut receipts = Vec::new();
+        for task in tasks {
+            match task.await {
+                Ok(receipt) => receipts.push(receipt?),
+                Err(e) => return Err(CollectError::TaskFailed(e)),
+            }
+        }
+
+        Ok(receipts)
+    }
+}
+
 use crate::err;
 use std::collections::BTreeMap;
-use tokio::task;
 
 fn parse_geth_diff_object(
     map: ethers::utils::__serde_json::Map<String, ethers::utils::__serde_json::Value>,
@@ -563,63 +620,4 @@ fn parse_geth_diff_object(
         .map_err(|_| err("cannot deserialize pre diff"))?;
 
     Ok(DiffMode { pre, post })
-}
-
-impl Source {
-    /// get gas used by transactions in block
-    pub async fn get_txs_gas_used(&self, block: &Block<Transaction>) -> Result<Vec<u64>> {
-        match get_txs_gas_used_per_block(block, self.fetcher.clone()).await {
-            Ok(value) => Ok(value),
-            Err(_) => get_txs_gas_used_per_tx(block, self.fetcher.clone()).await,
-        }
-    }
-}
-
-async fn get_txs_gas_used_per_block<P: JsonRpcClient>(
-    block: &Block<Transaction>,
-    fetcher: Arc<Fetcher<P>>,
-) -> Result<Vec<u64>> {
-    // let fetcher = Arc::new(fetcher);
-    let block_number = match block.number {
-        Some(number) => number,
-        None => return Err(CollectError::CollectError("no block number".to_string())),
-    };
-    let receipts = fetcher.get_block_receipts(block_number.as_u64()).await?;
-    let mut gas_used: Vec<u64> = Vec::new();
-    for receipt in receipts {
-        match receipt.gas_used {
-            Some(value) => gas_used.push(value.as_u64()),
-            None => return Err(CollectError::CollectError("no gas_used for tx".to_string())),
-        }
-    }
-    Ok(gas_used)
-}
-
-async fn get_txs_gas_used_per_tx<P: JsonRpcClient + 'static>(
-    block: &Block<Transaction>,
-    fetcher: Arc<Fetcher<P>>,
-) -> Result<Vec<u64>> {
-    // let fetcher = Arc::new(*fetcher.clone());
-    let mut tasks = Vec::new();
-    for tx in &block.transactions {
-        let tx_clone = tx.hash;
-        let fetcher = fetcher.clone();
-        let task = task::spawn(async move {
-            match fetcher.get_transaction_receipt(tx_clone).await? {
-                Some(receipt) => Ok(receipt.gas_used),
-                None => Err(CollectError::CollectError("could not find tx receipt".to_string())),
-            }
-        });
-        tasks.push(task);
-    }
-
-    let mut gas_used: Vec<u64> = Vec::new();
-    for task in tasks {
-        match task.await {
-            Ok(Ok(Some(value))) => gas_used.push(value.as_u64()),
-            _ => return Err(CollectError::CollectError("gas_used not available from node".into())),
-        }
-    }
-
-    Ok(gas_used)
 }


### PR DESCRIPTION
## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

resolves #93

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

To add a robust fallback mechanism for `eth_getBlockReceipts`, which had become outdated after recent updates, I created an extension trait `FetcherExt`. This trait is implemented for `Arc<Fetcher<P>>` and allows us to use reference of rate-limited providers over multiple tasks. I welcome any feedback on how to test this implementation effectively.

command tested:
```
$ cryo txs -b 145968168:145968169 --rpc https://arb1.arbitrum.io/rpc
```

before:
```
...
collecting data
───────────────
started at 2023-11-01 15:54:01.276
   done at 2023-11-01 15:54:01.639


error summary
─────────────
(errors in 1 chunks)
- Failed to get block: (code: -32601, message: the method eth_getBlockReceipts does not exist/is not available, data: None) (1x)


collection summary
──────────────────
- total duration: 0.362 seconds
- total chunks: 1
    - chunks errored:   1 / 1 (100.0%)
    - chunks skipped:   0 / 1 (0.0%)
    - chunks collected: 0 / 1 (0.0%)
- blocks collected: 0
    - blocks per second: 0.0
    - blocks per minute: 0.0
    - blocks per hour:   0.0
    - blocks per day:    0.0
```

after:
```
...
collecting data
───────────────
started at 2023-11-01 15:43:00.476
   done at 2023-11-01 15:43:01.056


collection summary
──────────────────
- total duration: 0.579 seconds
- total chunks: 1
    - chunks errored:   0 / 1 (0.0%)
    - chunks skipped:   0 / 1 (0.0%)
    - chunks collected: 1 / 1 (100.0%)
- blocks collected: 1
    - blocks per second:    1.7
    - blocks per minute:  103.5
    - blocks per hour:  6,207.1
    - blocks per day: 148,991.2
```

## PR Checklist

-   [ ] Added Tests
-   [x] Added Documentation
-   [ ] Breaking changes
