### PR TITLE
Add block_timestamp, block_hash as optional columns to transactions

### DIFF
--- a/crates/freeze/src/multi_datasets/blocks_and_transactions.rs
+++ b/crates/freeze/src/multi_datasets/blocks_and_transactions.rs
@@ -46,7 +46,7 @@ impl CollectByTransaction for BlocksAndTransactions {
     );
 
     async fn extract(request: Params, source: Arc<Source>, query: Arc<Query>) -> R<Self::Response> {
-        let (tx, receipt, exclude_failed) =
+        let (tx, receipt, exclude_failed, timestamp) =
             <Transactions as CollectByTransaction>::extract(request, source.clone(), query).await?;
         let block_number = tx.block_number.ok_or(err("no block number for tx"))?.as_u64();
         let block = source
@@ -54,16 +54,23 @@ impl CollectByTransaction for BlocksAndTransactions {
             .get_block(block_number)
             .await?
             .ok_or(CollectError::CollectError("block not found".to_string()))?;
-        Ok((block, (tx, receipt, exclude_failed)))
+        Ok((block, (tx, receipt, exclude_failed, timestamp)))
     }
 
     fn transform(response: Self::Response, columns: &mut Self, query: &Arc<Query>) -> R<()> {
         let BlocksAndTransactions(blocks, transactions) = columns;
-        let (block, (tx, receipt, exclude_failed)) = response;
+        let (block, (tx, receipt, exclude_failed, timestamp)) = response;
         let schema = query.schemas.get_schema(&Datatype::Blocks)?;
         blocks::process_block(block, blocks, schema)?;
         let schema = query.schemas.get_schema(&Datatype::Transactions)?;
-        transactions::process_transaction(tx, receipt, transactions, schema, exclude_failed)?;
+        transactions::process_transaction(
+            tx,
+            receipt,
+            transactions,
+            schema,
+            exclude_failed,
+            timestamp,
+        )?;
         Ok(())
     }
 }


### PR DESCRIPTION

## Motivation
I would like to propose optional columns to transactions to include block_timestamp and block_hash. In some cases it is good to have this information directly in the transactions and not to have to link it from the blocks.

## Solution
I have added default columns to transactions to be the original field set and extended the CollectByBlock and CollectByTransaction implementations for BlocksAndTransactions and Transactions.

Please let me know if I should extend some tests, I haven't found any related to that part of code or maybe I missed something.

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
