### PR TITLE
Fix typo in error handling comment

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -20,13 +20,13 @@ async fn main() -> Result<()> {
         Ok(Some(_freeze_summary)) => std::process::exit(1),
         Ok(None) => Ok(()),
         Err(e) => {
-            // handle release build
+            // handle debug build
             #[cfg(debug_assertions)]
             {
                 return Err(eyre::Report::from(e))
             }
 
-            // handle debug build
+            // handle release build
             #[cfg(not(debug_assertions))]
             {
                 println!("{}", e);


### PR DESCRIPTION
Looks like the comments are swapped.
[cfg(not(debug_assertions))] is for release builds, and [cfg(debug_assertions)] for debug builds.