### PR TITLE
refactor: remove NumberChunk's numbers() function

### DIFF
--- a/crates/freeze/src/types/chunks/number_chunk.rs
+++ b/crates/freeze/src/types/chunks/number_chunk.rs
@@ -49,15 +49,6 @@ impl ChunkData for NumberChunk {
 }
 
 impl NumberChunk {
-    /// get list of block numbers in chunk
-    /// TODO: remove in favor of values()
-    pub fn numbers(&self) -> Vec<u64> {
-        match self {
-            NumberChunk::Numbers(numbers) => numbers.to_vec(),
-            NumberChunk::Range(start, end) => (*start..=*end).collect(),
-        }
-    }
-
     /// convert block range to a list of Filters for get_logs()
     pub fn to_log_filter_options(&self, log_request_size: &u64) -> Vec<FilterBlockOption> {
         match self {

--- a/crates/freeze/src/types/chunks/subchunks.rs
+++ b/crates/freeze/src/types/chunks/subchunks.rs
@@ -46,7 +46,7 @@ fn to_single_chunk(chunks: &Vec<BlockChunk>) -> BlockChunk {
     match (chunks.len(), chunks.get(0)) {
         (1, Some(chunk)) => chunk.clone(),
         _ => {
-            let numbers = chunks.iter().flat_map(|x| x.numbers()).collect();
+            let numbers = chunks.iter().flat_map(|x| x.values()).collect();
             BlockChunk::Numbers(numbers)
         }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/paradigmxyz/flood/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running ruff and building the
documentation.
-->

## Motivation

`NumberChunk` had a method named `numbers()` that had a comment mentioning it was to be replaced by `values()`.

## Solution

I replaced the remaining usage of `numbers()` with `values()` and deleted `numbers()`.
For testing, I ran a `cryo log` command for for a given address for a certain range of blocks and checked that the output contained all the logs seen for that address on etherscan, along with a temporary print statement (not in the commit) used to print out all the block numbers in `block_numbers` in `parse_partitions`.

