### PR TITLE
docs: fix typo in block number ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,8 +245,8 @@ Block specification syntax
 - numbers can contain { _ . K M B }  5_000 5K 15M 15.5M
 - omitting range end means latest    15.5M: == 15.5M:latest
 - omitting range start means 0       :700 == 0:700
-- minus on start means minus end     -1000:7000 == 6000:7000
-- plus sign on end means plus start  15M:+1000 == 15M:15.001K
+- minus on start means minus end     -1000:7000 == 6001:7000
+- plus sign on end means plus start  15M:+1000 == 15M:15.001M
 - can use every nth value            2000:5000:1000 == 2000 3000 4000
 - can use n values total             100:200/5 == 100 124 149 174 199
 

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Block specification syntax
 - numbers can contain { _ . K M B }  5_000 5K 15M 15.5M
 - omitting range end means latest    15.5M: == 15.5M:latest
 - omitting range start means 0       :700 == 0:700
-- minus on start means minus end     -1000:7000 == 6001:7000
+- minus on start means minus end     -1000:7000 == 6001:7001
 - plus sign on end means plus start  15M:+1000 == 15M:15.001M
 - can use every nth value            2000:5000:1000 == 2000 3000 4000
 - can use n values total             100:200/5 == 100 124 149 174 199


### PR DESCRIPTION
As of the test case below, the starting and block number range for the case when we have a minus on the start should be incremented by 1

![image](https://github.com/paradigmxyz/cryo/assets/68152521/1fc40acb-a308-45ff-bd1a-f76e89809c1c)

Also a typo in the unit for the case when "plus sign on end means plus start"


