### PR TITLE
Support filtering & decoding transaction input for `txs` dataset with `--function-signature`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "cryo_python"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "cryo_cli",
  "cryo_freeze",

--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -248,6 +248,10 @@ pub struct Args {
     #[arg(long, value_name = "SIG", help_heading = "Dataset-specific Options", num_args(1..))]
     pub event_signature: Option<String>,
 
+    /// Function signature for transaction calldata decoding
+    #[arg(long, value_name = "SIG", help_heading = "Dataset-specific Options", num_args(1..))]
+    pub function_signature: Option<String>,
+
     /// Blocks per request (eth_getLogs)
     #[arg(
         long,

--- a/crates/freeze/src/types/decoders/calldata_decoder.rs
+++ b/crates/freeze/src/types/decoders/calldata_decoder.rs
@@ -1,0 +1,211 @@
+use ethers_core::{abi::{self, HumanReadableParser, Token, Param, ParamType, AbiEncode}, types::{U256, I256}};
+use polars::{series::Series, prelude::NamedFrom};
+
+use crate::{U256Type, ColumnEncoding, CollectError, ToU256Series, err};
+
+/// container for calldata decoding context
+#[derive(Clone, Debug, PartialEq)]
+pub struct CalldataDecoder {
+    /// the raw function signature string ex: transfer(address to, uint256 value)
+    pub raw: String,
+    /// decoded abi type of function signature string
+    pub function: abi::Function,
+    /// argument names of function
+    pub args: Vec<String>,
+}
+
+impl CalldataDecoder {
+    /// create a new CalldataDecoder from function signature
+    pub fn new(function_signature: String) -> Result<Self, String> {
+        match HumanReadableParser::parse_function(function_signature.as_str()) {
+            Ok(function) => {
+                let args = function
+                    .inputs
+                    .clone()
+                    .into_iter()
+                    .enumerate()
+                    .map(
+                        |(_i, param)| {
+                            // if param.name.is_empty() {
+                            //     format!("arg_{}", i)
+                            // } else {
+                            //     param.name
+                            // }
+                            param.name
+                        },
+                    )
+                    .collect();
+                Ok(Self { function, raw: function_signature.clone(), args })
+            }
+            Err(e) => {
+                let err = format!(
+                    "incorrectly formatted function {} (expect something like function transfer(address,uint256) err: {}",
+                    function_signature, e
+                );
+                eprintln!("{}", err);
+                Err(err)
+            }
+        }
+    }
+
+    /// data should never be mixed type, otherwise this will return inconsistent results
+    pub fn make_series(
+        &self,
+        name: String,
+        data: Vec<Token>,
+        chunk_len: usize,
+        u256_types: &[U256Type],
+        column_encoding: &ColumnEncoding,
+    ) -> Result<Vec<Series>, CollectError> {
+        // This is a smooth brain way of doing this, but I can't think of a better way right now
+        let mut ints: Vec<i64> = vec![];
+        let mut uints: Vec<u64> = vec![];
+        let mut str_ints: Vec<String> = vec![];
+        let mut u256s: Vec<U256> = vec![];
+        let mut i256s: Vec<I256> = vec![];
+        let mut bytes: Vec<Vec<u8>> = vec![];
+        let mut hexes: Vec<String> = vec![];
+        let mut bools: Vec<bool> = vec![];
+        let mut strings: Vec<String> = vec![];
+        // TODO: support array & tuple types
+
+        let param = self
+            .function
+            .inputs
+            .clone()
+            .into_iter()
+            .filter(|i| i.name == name)
+            .collect::<Vec<Param>>();
+        let param = param.first();
+
+        for token in data {
+            match token {
+                Token::Address(a) => match column_encoding {
+                    ColumnEncoding::Binary => bytes.push(a.to_fixed_bytes().into()),
+                    ColumnEncoding::Hex => hexes.push(format!("{:?}", a)),
+                },
+                Token::FixedBytes(b) => match column_encoding {
+                    ColumnEncoding::Binary => bytes.push(b),
+                    ColumnEncoding::Hex => hexes.push(b.encode_hex()),
+                },
+                Token::Bytes(b) => match column_encoding {
+                    ColumnEncoding::Binary => bytes.push(b),
+                    ColumnEncoding::Hex => hexes.push(b.encode_hex()),
+                },
+                Token::Uint(i) => match param {
+                    Some(param) => match param.kind.clone() {
+                        ParamType::Uint(size) => {
+                            if size <= 64 {
+                                uints.push(i.as_u64())
+                            } else {
+                                u256s.push(i)
+                            }
+                        }
+                        _ => str_ints.push(i.to_string()),
+                    },
+                    None => match i.try_into() {
+                        Ok(i) => ints.push(i),
+                        Err(_) => str_ints.push(i.to_string()),
+                    },
+                },
+                Token::Int(i) => {
+                    let i = I256::from_raw(i);
+                    match param {
+                        Some(param) => match param.kind.clone() {
+                            ParamType::Int(size) => {
+                                if size <= 64 {
+                                    ints.push(i.as_i64())
+                                } else {
+                                    i256s.push(i)
+                                }
+                            }
+                            _ => str_ints.push(i.to_string()),
+                        },
+                        None => match i.try_into() {
+                            Ok(i) => ints.push(i),
+                            Err(_) => str_ints.push(i.to_string()),
+                        },
+                    }
+                }
+                Token::Bool(b) => bools.push(b),
+                Token::String(s) => strings.push(s),
+                Token::Array(_) | Token::FixedArray(_) => {}
+                Token::Tuple(_) => {}
+            }
+        }
+        let mixed_length_err = format!("could not parse column {}, mixed type", name);
+        let mixed_length_err = mixed_length_err.as_str();
+
+        // check each vector, see if it contains any values, if it does, check if it's the same
+        // length as the input data and map to a series
+        let name = format!("param__{}", name);
+        if !ints.is_empty() {
+            Ok(vec![Series::new(name.as_str(), ints)])
+        } else if !i256s.is_empty() {
+            let mut series_vec = Vec::new();
+            for u256_type in u256_types.iter() {
+                series_vec.push(i256s.to_u256_series(
+                    name.clone(),
+                    u256_type.clone(),
+                    column_encoding,
+                )?)
+            }
+            Ok(series_vec)
+        } else if !u256s.is_empty() {
+            let mut series_vec: Vec<Series> = Vec::new();
+            for u256_type in u256_types.iter() {
+                series_vec.push(u256s.to_u256_series(
+                    name.clone(),
+                    u256_type.clone(),
+                    column_encoding,
+                )?)
+            }
+            Ok(series_vec)
+        } else if !uints.is_empty() {
+            Ok(vec![Series::new(name.as_str(), uints)])
+        } else if !str_ints.is_empty() {
+            Ok(vec![Series::new(name.as_str(), str_ints)])
+        } else if !bytes.is_empty() {
+            if bytes.len() != chunk_len {
+                return Err(err(mixed_length_err))
+            }
+            Ok(vec![Series::new(name.as_str(), bytes)])
+        } else if !hexes.is_empty() {
+            if hexes.len() != chunk_len {
+                return Err(err(mixed_length_err))
+            }
+            Ok(vec![Series::new(name.as_str(), hexes)])
+        } else if !bools.is_empty() {
+            if bools.len() != chunk_len {
+                return Err(err(mixed_length_err))
+            }
+            Ok(vec![Series::new(name.as_str(), bools)])
+        } else if !strings.is_empty() {
+            if strings.len() != chunk_len {
+                return Err(err(mixed_length_err))
+            }
+            Ok(vec![Series::new(name.as_str(), strings)])
+        } else {
+            // case where no data was passed
+            Ok(vec![Series::new(name.as_str(), vec![None::<u64>; chunk_len])])
+        }
+    }
+}
+
+mod tests {
+    #[allow(unused_imports)]
+    use super::CalldataDecoder;
+
+    #[test]
+    fn test_human_readable_parser() {
+        let decoder =
+            CalldataDecoder::new("transfer(address to,uint256 value)".to_string()).unwrap();
+        assert_eq!(decoder.args, vec!["to".to_string(), "value".to_string()]);
+    }
+
+    // #[test]
+    // fn test_human_readable_parser_without_arg_name() {
+    //     let decoder = CalldataDecoder::new("transfer(address,uint256)".to_string()).unwrap();
+    //     assert_eq!(decoder.args, vec!["arg_0".to_string(), "arg_1".to_string()]);
+    // }
+}

--- a/crates/freeze/src/types/decoders/mod.rs
+++ b/crates/freeze/src/types/decoders/mod.rs
@@ -1,3 +1,6 @@
 /// log decoder
 pub mod log_decoder;
 pub use log_decoder::*;
+/// calldata decoder
+pub mod calldata_decoder;
+pub use calldata_decoder::*;

--- a/crates/freeze/src/types/schemas.rs
+++ b/crates/freeze/src/types/schemas.rs
@@ -1,7 +1,7 @@
 /// types and functions related to schemas
 use std::collections::HashMap;
 
-use crate::{err, CollectError, ColumnEncoding, Datatype, LogDecoder};
+use crate::{err, CalldataDecoder, CollectError, ColumnEncoding, Datatype, LogDecoder};
 use indexmap::{IndexMap, IndexSet};
 use thiserror::Error;
 
@@ -39,6 +39,9 @@ pub struct Table {
 
     /// log decoder for table
     pub log_decoder: Option<LogDecoder>,
+
+    /// calldata decoder for table
+    pub calldata_decoder: Option<CalldataDecoder>,
 }
 
 impl Table {
@@ -174,6 +177,7 @@ impl Datatype {
         columns: &Option<Vec<String>>,
         sort: Option<Vec<String>>,
         log_decoder: Option<LogDecoder>,
+        calldata_decoder: Option<CalldataDecoder>,
     ) -> Result<Table, SchemaError> {
         let column_types = self.column_types();
         let all_columns = column_types.keys().map(|k| k.to_string()).collect();
@@ -201,6 +205,7 @@ impl Datatype {
             u256_types: u256_types.to_owned(),
             binary_type: binary_column_format.clone(),
             log_decoder,
+            calldata_decoder,
         };
         Ok(schema)
     }
@@ -248,14 +253,32 @@ mod tests {
     fn test_table_schema_explicit_cols() {
         let cols = Some(vec!["block_number".to_string(), "block_hash".to_string()]);
         let table = Datatype::Blocks
-            .table_schema(&get_u256_types(), &ColumnEncoding::Hex, &None, &None, &cols, None, None)
+            .table_schema(
+                &get_u256_types(),
+                &ColumnEncoding::Hex,
+                &None,
+                &None,
+                &cols,
+                None,
+                None,
+                None,
+            )
             .unwrap();
         assert_eq!(vec!["block_number", "block_hash"], table.columns());
 
         // "all" marker support
         let cols = Some(vec!["all".to_string()]);
         let table = Datatype::Blocks
-            .table_schema(&get_u256_types(), &ColumnEncoding::Hex, &None, &None, &cols, None, None)
+            .table_schema(
+                &get_u256_types(),
+                &ColumnEncoding::Hex,
+                &None,
+                &None,
+                &cols,
+                None,
+                None,
+                None,
+            )
             .unwrap();
         assert_eq!(15, table.columns().len());
         assert!(table.columns().contains(&"block_hash"));
@@ -274,6 +297,7 @@ mod tests {
                 &None,
                 None,
                 None,
+                None,
             )
             .unwrap();
         assert_eq!(9, table.columns().len());
@@ -288,6 +312,7 @@ mod tests {
                 &inc_cols,
                 &None,
                 &None,
+                None,
                 None,
                 None,
             )
@@ -306,6 +331,7 @@ mod tests {
                 &None,
                 None,
                 None,
+                None,
             )
             .unwrap();
         assert_eq!(15, table.columns().len());
@@ -317,7 +343,16 @@ mod tests {
     fn test_table_schema_exclude_cols() {
         // defaults
         let table = Datatype::Blocks
-            .table_schema(&get_u256_types(), &ColumnEncoding::Hex, &None, &None, &None, None, None)
+            .table_schema(
+                &get_u256_types(),
+                &ColumnEncoding::Hex,
+                &None,
+                &None,
+                &None,
+                None,
+                None,
+                None,
+            )
             .unwrap();
         assert_eq!(8, table.columns().len());
         assert!(table.columns().contains(&"author"));
@@ -331,6 +366,7 @@ mod tests {
                 &None,
                 &ex_cols,
                 &None,
+                None,
                 None,
                 None,
             )
@@ -348,6 +384,7 @@ mod tests {
                 &None,
                 &ex_cols,
                 &None,
+                None,
                 None,
                 None,
             )
@@ -368,6 +405,7 @@ mod tests {
                 &inc_cols,
                 &ex_cols,
                 &None,
+                None,
                 None,
                 None,
             )

--- a/crates/python/rust/collect_adapter.rs
+++ b/crates/python/rust/collect_adapter.rs
@@ -64,6 +64,7 @@ use cryo_freeze::collect;
         verbose = false,
         no_verbose = false,
         event_signature = None,
+        function_signature = None,
     )
 )]
 #[allow(clippy::too_many_arguments)]
@@ -125,6 +126,7 @@ pub fn _collect(
     verbose: bool,
     no_verbose: bool,
     event_signature: Option<String>,
+    function_signature: Option<String>,
 ) -> PyResult<&PyAny> {
     if let Some(command) = command {
         pyo3_asyncio::tokio::future_into_py(py, async move {
@@ -190,6 +192,7 @@ pub fn _collect(
             verbose,
             no_verbose,
             event_signature,
+            function_signature,
         };
         pyo3_asyncio::tokio::future_into_py(py, async move {
             match run_collect(args).await {

--- a/crates/python/rust/freeze_adapter.rs
+++ b/crates/python/rust/freeze_adapter.rs
@@ -61,6 +61,7 @@ use cryo_cli::{run, Args};
         verbose = false,
         no_verbose = false,
         event_signature = None,
+        function_signature = None,
     )
 )]
 #[allow(clippy::too_many_arguments)]
@@ -122,6 +123,7 @@ pub fn _freeze(
     verbose: bool,
     no_verbose: bool,
     event_signature: Option<String>,
+    function_signature: Option<String>,
 ) -> PyResult<&PyAny> {
     if let Some(command) = command {
         freeze_command(py, command)
@@ -182,6 +184,7 @@ pub fn _freeze(
             verbose,
             no_verbose,
             event_signature,
+            function_signature,
         };
 
         pyo3_asyncio::tokio::future_into_py(py, async move {


### PR DESCRIPTION
## Motivation

Closes #140.

## Solution

Most codes are copied from log_decoder which makes a lot of duplicate codes, some seems to be able to be abstracted. Refactoring for removing duplicate codes & documentation TBD, review for current code structure would be very helpful.

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
