### PR TITLE
refactor: streamlining `DimIsNone` trait and optimizing `parse_u256_types`

### DIFF
--- a/crates/cli/src/parse/query.rs
+++ b/crates/cli/src/parse/query.rs
@@ -79,20 +79,7 @@ impl DimIsNone for Args {
     }
 
     fn dim_is_none(&self, dim: &Dim) -> bool {
-        match dim {
-            Dim::BlockNumber => self.blocks.is_none(),
-            Dim::TransactionHash => self.txs.is_none(),
-            Dim::Address => self.address.is_none(),
-            Dim::FromAddress => self.from_address.is_none(),
-            Dim::ToAddress => self.to_address.is_none(),
-            Dim::Contract => self.contract.is_none(),
-            Dim::CallData => self.call_data.is_none(),
-            Dim::Slot => self.slot.is_none(),
-            Dim::Topic0 => self.topic0.is_none(),
-            Dim::Topic1 => self.topic1.is_none(),
-            Dim::Topic2 => self.topic2.is_none(),
-            Dim::Topic3 => self.topic3.is_none(),
-        }
+        !self.dim_is_some(dim)
     }
 }
 

--- a/crates/cli/src/parse/schemas.rs
+++ b/crates/cli/src/parse/schemas.rs
@@ -171,7 +171,7 @@ fn ensure_excluded_columns(
 
 fn parse_sort_columns(
     raw_sort: &Option<Vec<String>>,
-    datatypes: &Vec<Datatype>,
+    datatypes: &[Datatype],
 ) -> Result<HashMap<Datatype, Option<Vec<String>>>, ParseError> {
     match raw_sort {
         None => Ok(HashMap::from_iter(

--- a/crates/cli/src/parse/schemas.rs
+++ b/crates/cli/src/parse/schemas.rs
@@ -85,32 +85,27 @@ pub(crate) fn parse_schemas(
 }
 
 fn parse_u256_types(args: &Args) -> Result<Vec<U256Type>, ParseError> {
-    if let Some(raw_u256_types) = args.u256_types.clone() {
-        let mut u256_types: Vec<U256Type> = Vec::new();
-        for raw in raw_u256_types.iter() {
-            let u256_type = match raw.to_lowercase() {
-                raw if raw == "binary" => U256Type::Binary,
-                raw if raw == "string" => U256Type::String,
-                raw if raw == "str" => U256Type::String,
-                raw if raw == "f32" => U256Type::F32,
-                raw if raw == "float32" => U256Type::F32,
-                raw if raw == "f64" => U256Type::F64,
-                raw if raw == "float64" => U256Type::F64,
-                raw if raw == "float" => U256Type::F64,
-                raw if raw == "u32" => U256Type::U32,
-                raw if raw == "uint32" => U256Type::U32,
-                raw if raw == "u64" => U256Type::U64,
-                raw if raw == "uint64" => U256Type::U64,
-                raw if raw == "decimal128" => U256Type::Decimal128,
-                raw if raw == "d128" => U256Type::Decimal128,
-                _ => return Err(ParseError::ParseError("bad u256 type".to_string())),
-            };
-            u256_types.push(u256_type);
-        }
-        Ok(u256_types)
-    } else {
-        Ok(vec![U256Type::Binary, U256Type::String, U256Type::F64])
-    }
+    args.u256_types.as_ref().map_or(
+        Ok(vec![U256Type::Binary, U256Type::String, U256Type::F64]),
+        |raw_u256_types| {
+            raw_u256_types
+                .iter()
+                .map(|raw| {
+                    let lower_case = raw.to_lowercase();
+                    match lower_case.as_str() {
+                        "binary" => Ok(U256Type::Binary),
+                        "string" | "str" => Ok(U256Type::String),
+                        "f32" | "float32" => Ok(U256Type::F32),
+                        "f64" | "float64" | "float" => Ok(U256Type::F64),
+                        "u32" | "uint32" => Ok(U256Type::U32),
+                        "u64" | "uint64" => Ok(U256Type::U64),
+                        "decimal128" | "d128" => Ok(U256Type::Decimal128),
+                        _ => Err(ParseError::ParseError(format!("invalid u256 type: {}", raw))),
+                    }
+                })
+                .collect()
+        },
+    )
 }
 
 fn ensure_included_columns(

--- a/crates/freeze/src/types/chunks/subchunks.rs
+++ b/crates/freeze/src/types/chunks/subchunks.rs
@@ -42,7 +42,7 @@ impl Subchunk for Vec<BlockChunk> {
     }
 }
 
-fn to_single_chunk(chunks: &Vec<BlockChunk>) -> BlockChunk {
+fn to_single_chunk(chunks: &[BlockChunk]) -> BlockChunk {
     match (chunks.len(), chunks.first()) {
         (1, Some(chunk)) => chunk.clone(),
         _ => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/paradigmxyz/flood/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running ruff and building the
documentation.
-->

## Motivation

The primary goal of these changes is to enhance the readability and efficiency of the code in the `Args` struct. In its previous state, certain functions like `dim_is_none` and `parse_u256_types` were more verbose than necessary and did not fully leverage Rust's expressive capabilities. By refactoring these functions, we aim to make the codebase cleaner, more maintainable, and easier for other contributors to understand and work with.

## Solution

1. `DimIsNone` Trait Refactoring:
   - Simplified the `dim_is_none` function by returning the negation of `dim_is_some`, thereby removing redundant match statements.

2. `parse_u256_types` Function Optimization:
   - Refactored to use `map_or` and `map` for more idiomatic and streamlined logic.
   - Consolidated string comparisons in pattern matching to improve performance and readability.

These changes maintain the existing functionality while significantly enhancing code quality.
