### PR TITLE
Typos Update uniswap.sh

### DIFF
--- a/examples/uniswap.sh
+++ b/examples/uniswap.sh
@@ -4,8 +4,8 @@
 
 # This script is
 # - idempotent: run the script as many times as you want, the data will be fine
-# - interuptable: you can interrupt the script whenever you want, the data will be fine
-# - incremental: only missing data is collected. re-runing the script does not re-collect data
+# - interruptible: you can interrupt the script whenever you want, the data will be fine
+# - incremental: only missing data is collected. re-running the script does not re-collect data
 
 # uniswap v2 pools
 cryo logs \


### PR DESCRIPTION
#### Changes Made:  
1. **Corrected spelling of "interuptable":**  
   - **Original:** "interuptable: you can interrupt the script whenever you want, the data will be fine"  
   - **Corrected:** "interruptible: you can interrupt the script whenever you want, the data will be fine"  
   - **Reason:** "Interuptable" is a misspelling. The correct word is "interruptible," ensuring clarity and grammatical accuracy.  

2. **Corrected spelling of "re-runing":**  
   - **Original:** "re-runing the script does not re-collect data"  
   - **Corrected:** "re-running the script does not re-collect data"  
   - **Reason:** "Re-runing" is a misspelling. The correct word is "re-running," which accurately conveys the intended meaning.  

#### Importance of Fixing These Issues:  
Clear and error-free comments are crucial for maintaining the readability and professionalism of the codebase. These changes help developers better understand the script and prevent any potential confusion caused by incorrect terminology.  

#### Testing:  
No functional changes were made; only comments were updated. The script itself remains unaffected.  