### PR TITLE
Fix typos Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ to discuss cryo, check out [the telegram group](https://t.me/paradigm_data)
 2. [Installation](#installation)
 3. [Data Schema](#data-schemas)
 4. [Code Guide](#code-guide)
-5. [Documenation](#documentation)
+5. [Documentation](#documentation)
     1. [Basics](#cryo-help)
     2. [Syntax](#cryo-syntax)
     3. [Datasets](#cryo-datasets)
@@ -64,7 +64,7 @@ This method requires having rust installed. See [rustup](https://rustup.rs/) for
 
 Make sure that `~/.cargo/bin` is on your `PATH`. One way to do this is by adding the line `export PATH="$HOME/.cargo/bin:$PATH"` to your `~/.bashrc` or `~/.profile`.
 
-### Python Instalation
+### Python Installation
 
 `cryo` can also be installed as a python package:
 


### PR DESCRIPTION
**Description**:  
This pull request fixes two typos found in the documentation that could cause confusion or appear unprofessional to readers:  

1. **"Python Instalation" heading**  
   - **Error**: *Instalation*  
   - **Correction**: *Installation*  
   - **Importance**: This is a prominent section header, and such errors may reduce the credibility of the documentation. Correct spelling ensures a polished and professional presentation.

2. **"Documenation" in the Table of Contents**  
   - **Error**: *Documenation*  
   - **Correction**: *Documentation*  
   - **Importance**: The Table of Contents is a crucial navigational aid. Typographical errors in it may confuse users and create inconsistency with the linked section headings. This fix ensures better user experience and clarity.

Both fixes contribute to maintaining the high-quality standard of the repository's documentation.

## PR Checklist

-   [ ] Added Tests
-   [x] Added Documentation
-   [ ] Breaking changes
