### PR TITLE
Fix for Incorrect Variable Usage in Update erc20_balances.sh

### DIFF
--- a/examples/erc20_balances.sh
+++ b/examples/erc20_balances.sh
@@ -12,5 +12,5 @@ export WALLETS="0x0a59649758aa4d66e25f08dd01271e891fe52199 0xcee284f754e854890e3
 export BLOCKS="16M:17M/10"
 
 # collect data
-cryo erc20_balances --blocks $BLOCKS --contract $ERC20 --address $WALLET
+cryo erc20_balances --blocks $BLOCKS --contract $ERC20 --address $WALLETS
 


### PR DESCRIPTION
#### Problem
The script defines the environment variable `WALLETS`, which holds multiple addresses. However, in the command for fetching ERC20 balances, the script mistakenly uses a single address variable `$WALLET` (singular) instead of `$WALLETS` (plural).

#### Fix
To ensure the script processes all the addresses specified in the `WALLETS` variable, the incorrect variable `$WALLET` has been replaced with `$WALLETS`.

#### Corrected Code
```bash
cryo erc20_balances --blocks $BLOCKS --contract $ERC20 --address $WALLETS
```

#### Importance
This issue could lead to the script processing only the first address in the `WALLETS` list, rather than all the intended addresses. The fix ensures that the script properly uses all the addresses stored in the `WALLETS` variable, allowing for accurate and complete data collection.

---

## PR Checklist

-   [x] Added Tests
-   [x] Added Documentation
-   [x] Breaking changes
