### PR TITLE
Typo fixed Update uniswap.sh

### DIFF
--- a/examples/uniswap.sh
+++ b/examples/uniswap.sh
@@ -4,7 +4,7 @@
 
 # This script is
 # - idempotent: run the script as many times as you want, the data will be fine
-# - interuptable: you can interrupt the script whenever you want, the data will be fine
+# - interruptible: you can interrupt the script whenever you want, the data will be fine
 # - incremental: only missing data is collected. re-runing the script does not re-collect data
 
 # uniswap v2 pools


### PR DESCRIPTION
#### Description:
This pull request fixes a minor typo in a comment within the script. Specifically, the word "interuptable" was misspelled. The correct spelling is "interruptible."

#### Problem:
The typo could cause confusion for developers reading the script, as "interuptable" is not a standard word in English. Using the correct spelling "interruptible" ensures the comment is clear, professional, and easily understandable.

#### Impact:
While this change does not affect the functionality of the script, maintaining proper spelling in comments is important for readability, especially in collaborative projects. It prevents misunderstandings and ensures consistency in documentation.

#### Change:
The following line:

```bash
# - interuptable: you can interrupt the script whenever you want, the data will be fine
```

Has been corrected to:

```bash
# - interruptible: you can interrupt the script whenever you want, the data will be fine
```
