### PR TITLE
Fix Documentation Typos and Links

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ the requirements below.
 
 Bug fixes and new features should include tests.
 
-Contributors guide: https://github.com/paradigmxyz/flood/blob/master/CONTRIBUTING.md
+Contributors guide: https://github.com/paradigmxyz/cryo/blob/master/CONTRIBUTING.md
 
 The contributors guide includes instructions for running ruff and building the
 documentation.

--- a/crates/freeze/src/types/files.rs
+++ b/crates/freeze/src/types/files.rs
@@ -14,7 +14,7 @@ pub struct FileOutput {
     pub subdirs: Vec<SubDir>,
     /// Whether to overwrite existing files or skip them
     pub overwrite: bool,
-    /// File format to used for output files
+    /// File format to use for output files
     pub format: FileFormat,
     /// Number of rows per parquet row group
     pub row_group_size: Option<usize>,


### PR DESCRIPTION
Detailed Changes:
1. crates/freeze/src/types/files.rs:
- /// File format to used for output files
+ /// File format to use for output files
Reason: Fixed grammatical error. The phrase "to used" is incorrect English grammar. The correct form is "to use" when describing the purpose of the file format.

2. .github/PULL_REQUEST_TEMPLATE.md:
- Contributors guide: https://github.com/paradigmxyz/flood/blob/master/CONTRIBUTING.md
+ Contributors guide: https://github.com/paradigmxyz/cryo/blob/master/CONTRIBUTING.md
Reason: Fixed incorrect repository link. The link was pointing to a non-existent "flood" repository instead of the correct "cryo" repository. This ensures contributors are directed to the correct contributing guidelines.

PR Checklist
[x] Added Documentation Updates
[ ] Added Tests (not required for documentation fixes)
[ ] Breaking changes (none)