### PR TITLE
Improve Code Readability by Replacing ..Default::default() with Self::default()

### DIFF
--- a/crates/freeze/src/types/execution.rs
+++ b/crates/freeze/src/types/execution.rs
@@ -89,7 +89,7 @@ impl Default for ExecutionEnvBuilder {
 impl ExecutionEnvBuilder {
     /// initialize ExecutionEnvBuilder
     pub fn new() -> Self {
-        ExecutionEnvBuilder { ..Default::default() }
+        Self::default() 
     }
 
     /// dry run


### PR DESCRIPTION
Reason:
Using `Self::default()` makes the code more readable and understandable. It explicitly indicates the call to the `default` method for the current type (`Self`), which simplifies code comprehension, especially for developers familiar with the `Default` pattern.

`..Default::default()` adds redundancy since the `ExecutionEnvBuilder` object is already returned through the `default()` call. This simplification improves code readability and maintainability.
