### PR TITLE
fix: typos in documentation files

### DIFF
--- a/crates/freeze/src/datasets/balance_diffs.rs
+++ b/crates/freeze/src/datasets/balance_diffs.rs
@@ -34,7 +34,7 @@ impl CollectByBlock for BalanceDiffs {
         let include_txs = schema.has_column("transaction_hash");
         let (bn, txs, traces) =
             source.trace_block_state_diffs(request.block_number()? as u32, include_txs).await?;
-        let trace_resuls = traces.into_iter().map(|t| t.full_trace).collect();
+        let trace_results = traces.into_iter().map(|t| t.full_trace).collect();
         Ok((bn, txs, trace_resuls))
     }
 


### PR DESCRIPTION
**Description correction:**
Corrected `trace_resuls` to `trace_results`