### PR TITLE
Corrected contract address colname from erc20 to erc721 for erc721_transfers

### DIFF
--- a/crates/freeze/src/datasets/erc721_transfers.rs
+++ b/crates/freeze/src/datasets/erc721_transfers.rs
@@ -16,7 +16,7 @@ pub struct Erc721Transfers {
     transaction_index: Vec<u32>,
     log_index: Vec<u32>,
     transaction_hash: Vec<Vec<u8>>,
-    erc20: Vec<Vec<u8>>,
+    erc721: Vec<Vec<u8>>,
     from_address: Vec<Vec<u8>>,
     to_address: Vec<Vec<u8>>,
     token_id: Vec<U256>,
@@ -32,7 +32,7 @@ impl Dataset for Erc721Transfers {
             "transaction_index",
             "log_index",
             "transaction_hash",
-            "erc20",
+            "erc721",
             "from_address",
             "to_address",
             "token_id",
@@ -117,7 +117,7 @@ fn process_erc721_transfers(
             store!(schema, columns, transaction_index, ti as u32);
             store!(schema, columns, log_index, li as u32);
             store!(schema, columns, transaction_hash, tx.to_vec());
-            store!(schema, columns, erc20, log.address().to_vec());
+            store!(schema, columns, erc721, log.address().to_vec());
             store!(schema, columns, from_address, log.topics()[1][12..].to_vec());
             store!(schema, columns, to_address, log.topics()[2][12..].to_vec());
             store!(schema, columns, token_id, log.topics()[3].into());


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/paradigmxyz/cryo/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running ruff and building the
documentation.
-->

## Motivation

Fixes #230

Incorrect contract address column naming for erc721_transfers.

## Solution

Adjusted variable naming and column name string for erc721_transfers contract addresses from `erc20` to `erc721`.

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [X] Breaking changes

May break existing applications which are already using incorrect colname `erc20` for erc721_transfers.
