### PR TITLE
changed is_erc20_transfer to use Transfer signature instead of Approval

### DIFF
--- a/crates/freeze/src/datasets/erc20_transfers.rs
+++ b/crates/freeze/src/datasets/erc20_transfers.rs
@@ -101,7 +101,7 @@ impl CollectByTransaction for Erc20Transfers {
 fn is_erc20_transfer(log: &Log) -> bool {
     log.topics().len() == 3 &&
         log.data().data.len() == 32 &&
-        log.topics()[0] == ERC20::Approval::SIGNATURE_HASH
+        log.topics()[0] == ERC20::Transfer::SIGNATURE_HASH
 }
 
 /// process block into columns


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/paradigmxyz/cryo/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running ruff and building the
documentation.
-->

## Motivation

fixes #231

## Solution

Changed `erc20_transfers.rs` line 104 from:
```rust
log.topics()[0] == ERC20::Approval::SIGNATURE_HASH
```
to
```rust
log.topics()[0] == ERC20::Transfer::SIGNATURE_HASH
```

## PR Checklist

-   [ ] Added Tests
-   [ ] Added Documentation
-   [ ] Breaking changes
