### PR TITLE
chore: migrate from alloy 0.6.4 to 1.0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -62,9 +62,9 @@ checksum = "45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9"
 
 [[package]]
 name = "alloy"
-version = "0.6.4"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b524b8c28a7145d1fe4950f84360b5de3e307601679ff0558ddc20ea229399"
+checksum = "0093d23bf026b580c1f66ed3a053d8209c104a446c5264d3ad99587f6edef24e"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -87,38 +87,60 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.47"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18c5c520273946ecf715c0010b4e3503d7eba9893cd9ce6b7fff5654c4a3c470"
+checksum = "19a9cc9d81ace3da457883b0bdf76776e55f1b84219a9e9d55c27ad308548d3f"
 dependencies = [
  "alloy-primitives",
  "num_enum",
- "strum",
+ "strum 0.27.1",
 ]
 
 [[package]]
 name = "alloy-consensus"
-version = "0.6.4"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae09ffd7c29062431dd86061deefe4e3c6f07fa0d674930095f8dcedb0baf02c"
+checksum = "ad451f9a70c341d951bca4e811d74dbe1e193897acd17e9dbac1353698cc430b"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
+ "alloy-trie",
  "auto_impl",
  "c-kzg",
  "derive_more",
+ "either",
  "k256",
+ "once_cell",
+ "rand 0.8.5",
+ "secp256k1",
+ "serde",
+ "serde_with",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "alloy-consensus-any"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142daffb15d5be1a2b20d2cd540edbcef03037b55d4ff69dc06beb4d06286dba"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
  "serde",
 ]
 
 [[package]]
 name = "alloy-contract"
-version = "0.6.4"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66430a72d5bf5edead101c8c2f0a24bada5ec9f3cf9909b3e08b6d6899b4803e"
+checksum = "ebf25443920ecb9728cb087fe4dc04a0b290bd6ac85638c58fe94aba70f1a44e"
 dependencies = [
+ "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-json-abi",
  "alloy-network",
@@ -131,14 +153,14 @@ dependencies = [
  "alloy-transport",
  "futures",
  "futures-util",
- "thiserror",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "alloy-core"
-version = "0.8.13"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d22df68fa7d9744be0b1a9be3260e9aa089fbf41903ab182328333061ed186"
+checksum = "5968f48d7a62587cd874bd84034831da4f7f577ce5de984828e376766efc0f32"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -149,26 +171,38 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "0.8.13"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cf633ae9a1f0c82fdb9e559ed2be1c8e415c3e48fc47e1feaf32c6078ec0cdd"
+checksum = "f9135eb501feccf7f4cb8a183afd406a65483fdad7bbd7332d0470e5d725c92f"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
  "alloy-sol-type-parser",
  "alloy-sol-types",
- "const-hex",
  "itoa",
  "serde",
  "serde_json",
- "winnow",
+ "winnow 0.7.11",
+]
+
+[[package]]
+name = "alloy-eip2124"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "741bdd7499908b3aa0b159bba11e71c8cddd009a2c2eb7a06e825f1ec87900a5"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "crc",
+ "serde",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "alloy-eip2930"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0069cf0642457f87a01a014f6dc29d5d893cd4fd8fddf0c3cdfad1bb3ebafc41"
+checksum = "7b82752a889170df67bbb36d42ca63c531eb16274f0d7299ae2a680facba17bd"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -177,51 +211,55 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7702"
-version = "0.4.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6cee6a35793f3db8a5ffe60e86c695f321d081a567211245f503e8c498fce8"
+checksum = "9d4769c6ffddca380b0070d71c8b7f30bed375543fe76bb2f74ec0acf4b7cd16"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "derive_more",
  "k256",
  "serde",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "alloy-eips"
-version = "0.6.4"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b6aa3961694b30ba53d41006131a2fca3bdab22e4c344e46db2c639e7c2dfdd"
+checksum = "3056872f6da48046913e76edb5ddced272861f6032f09461aea1a2497be5ae5d"
 dependencies = [
+ "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
+ "auto_impl",
  "c-kzg",
  "derive_more",
- "once_cell",
+ "either",
  "serde",
  "sha2",
 ]
 
 [[package]]
 name = "alloy-genesis"
-version = "0.6.4"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53f7877ded3921d18a0a9556d55bedf84535567198c9edab2aa23106da91855"
+checksum = "c98fb40f07997529235cc474de814cd7bd9de561e101716289095696c0e4639d"
 dependencies = [
+ "alloy-eips",
  "alloy-primitives",
  "alloy-serde",
+ "alloy-trie",
  "serde",
 ]
 
 [[package]]
 name = "alloy-json-abi"
-version = "0.8.13"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a500037938085feed8a20dbfc8fce58c599db68c948cfae711147175dee392c"
+checksum = "8b26fdd571915bafe857fccba4ee1a4f352965800e46a53e4a5f50187b7776fa"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -231,46 +269,49 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.6.4"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3694b7e480728c0b3e228384f223937f14c10caef5a4c766021190fc8f283d35"
+checksum = "dc08b31ebf9273839bd9a01f9333cbb7a3abb4e820c312ade349dd18bdc79581"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
 [[package]]
 name = "alloy-network"
-version = "0.6.4"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea94b8ceb5c75d7df0a93ba0acc53b55a22b47b532b600a800a87ef04eb5b0b4"
+checksum = "ed117b08f0cc190312bf0c38c34cf4f0dabfb4ea8f330071c587cd7160a88cb2"
 dependencies = [
  "alloy-consensus",
+ "alloy-consensus-any",
  "alloy-eips",
  "alloy-json-rpc",
  "alloy-network-primitives",
  "alloy-primitives",
+ "alloy-rpc-types-any",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "alloy-signer",
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
+ "derive_more",
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "alloy-network-primitives"
-version = "0.6.4"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9f3e281005943944d15ee8491534a1c7b3cbf7a7de26f8c433b842b93eb5f9"
+checksum = "c7162ff7be8649c0c391f4e248d1273e85c62076703a1f3ec7daf76b283d886d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -281,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.13"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aeeb5825c2fc8c2662167058347cd0cafc3cb15bcb5cdb1758a63c2dca0409e"
+checksum = "a326d47106039f38b811057215a92139f46eef7983a4b77b10930a0ea5685b1e"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -292,14 +333,13 @@ dependencies = [
  "derive_more",
  "foldhash",
  "hashbrown 0.15.2",
- "hex-literal",
- "indexmap",
+ "indexmap 2.6.0",
  "itoa",
  "k256",
  "keccak-asm",
  "paste",
  "proptest",
- "rand",
+ "rand 0.9.1",
  "ruint",
  "rustc-hash",
  "serde",
@@ -309,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "0.6.4"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c1f9eede27bf4c13c099e8e64d54efd7ce80ef6ea47478aa75d5d74e2dba3b"
+checksum = "d84eba1fd8b6fe8b02f2acd5dd7033d0f179e304bd722d11e817db570d1fa6c4"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -322,8 +362,13 @@ dependencies = [
  "alloy-primitives",
  "alloy-pubsub",
  "alloy-rpc-client",
+ "alloy-rpc-types-anvil",
+ "alloy-rpc-types-debug",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
+ "alloy-rpc-types-txpool",
+ "alloy-signer",
+ "alloy-sol-types",
  "alloy-transport",
  "alloy-transport-http",
  "alloy-transport-ipc",
@@ -332,16 +377,16 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "dashmap 6.1.0",
+ "either",
  "futures",
  "futures-utils-wasm",
  "lru",
  "parking_lot",
  "pin-project",
  "reqwest",
- "schnellru",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "url",
@@ -350,21 +395,23 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "0.6.4"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f1f34232f77341076541c405482e4ae12f0ee7153d8f9969fc1691201b2247"
+checksum = "8550f7306e0230fc835eb2ff4af0a96362db4b6fc3f25767d161e0ad0ac765bf"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
  "alloy-transport",
  "bimap",
  "futures",
+ "parking_lot",
  "serde",
  "serde_json",
  "tokio",
  "tokio-stream",
  "tower",
  "tracing",
+ "wasmtimer",
 ]
 
 [[package]]
@@ -386,14 +433,14 @@ checksum = "2b09cae092c27b6f1bde952653a22708691802e57bfef4a2973b80bea21efd3f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.103",
 ]
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.6.4"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374dbe0dc3abdc2c964f36b3d3edf9cdb3db29d16bda34aa123f03d810bec1dd"
+checksum = "518a699422a3eab800f3dac2130d8f2edba8e4fff267b27a9c7dc6a2b0d313ee"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -402,6 +449,7 @@ dependencies = [
  "alloy-transport-http",
  "alloy-transport-ipc",
  "alloy-transport-ws",
+ "async-stream",
  "futures",
  "pin-project",
  "reqwest",
@@ -411,29 +459,65 @@ dependencies = [
  "tokio-stream",
  "tower",
  "tracing",
+ "tracing-futures",
  "url",
  "wasmtimer",
 ]
 
 [[package]]
 name = "alloy-rpc-types"
-version = "0.6.4"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c74832aa474b670309c20fffc2a869fa141edab7c79ff7963fad0a08de60bae1"
+checksum = "c000cab4ec26a4b3e29d144e999e1c539c2fa0abed871bf90311eb3466187ca8"
 dependencies = [
  "alloy-primitives",
+ "alloy-rpc-types-anvil",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
+ "alloy-rpc-types-txpool",
  "alloy-serde",
  "serde",
 ]
 
 [[package]]
-name = "alloy-rpc-types-engine"
-version = "0.6.4"
+name = "alloy-rpc-types-anvil"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56294dce86af23ad6ee8df46cf8b0d292eb5d1ff67dc88a0886051e32b1faf"
+checksum = "8abecc34549a208b5f91bc7f02df3205c36e2aa6586f1d9375c3382da1066b3b"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-any"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "508b2fbe66d952089aa694e53802327798806498cd29ff88c75135770ecaabfc"
+dependencies = [
+ "alloy-consensus-any",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-debug"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c832f2e851801093928dbb4b7bd83cd22270faf76b2e080646b806a285c8757"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-engine"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab52691970553d84879d777419fa7b6a2e92e9fe8641f9324cc071008c2f656"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -441,48 +525,62 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "derive_more",
+ "rand 0.8.5",
  "serde",
- "strum",
+ "strum 0.27.1",
 ]
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.6.4"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a477281940d82d29315846c7216db45b15e90bcd52309da9f54bcf7ad94a11"
+checksum = "fcaf7dff0fdd756a714d58014f4f8354a1706ebf9fa2cf73431e0aeec3c9431e"
 dependencies = [
  "alloy-consensus",
+ "alloy-consensus-any",
  "alloy-eips",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "derive_more",
  "itertools 0.13.0",
  "serde",
  "serde_json",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "0.6.4"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd8b4877ef520c138af702097477cdd19504a8e1e4675ba37e92ba40f2d3c6f"
+checksum = "6e3507a04e868dd83219ad3cd6a8c58aefccb64d33f426b3934423a206343e84"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "alloy-rpc-types-txpool"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eec36272621c3ac82b47dd77f0508346687730b1c2e3e10d3715705c217c0a05"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "serde",
 ]
 
 [[package]]
 name = "alloy-serde"
-version = "0.6.4"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dfa4a7ccf15b2492bb68088692481fd6b2604ccbee1d0d6c44c21427ae4df83"
+checksum = "730e8f2edf2fc224cabd1c25d090e1655fa6137b2e409f92e5eec735903f1507"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -491,23 +589,24 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "0.6.4"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e10aec39d60dc27edcac447302c7803d2371946fb737245320a05b78eb2fafd"
+checksum = "6b0d2428445ec13edc711909e023d7779618504c4800be055a5b940025dbafe3"
 dependencies = [
  "alloy-primitives",
  "async-trait",
  "auto_impl",
+ "either",
  "elliptic-curve",
  "k256",
- "thiserror",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "alloy-signer-local"
-version = "0.6.4"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8396f6dff60700bc1d215ee03d86ff56de268af96e2bf833a14d0bafcab9882"
+checksum = "e14fe6fedb7fe6e0dfae47fe020684f1d8e063274ef14bca387ddb7a6efa8ec1"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -515,96 +614,99 @@ dependencies = [
  "alloy-signer",
  "async-trait",
  "k256",
- "rand",
- "thiserror",
+ "rand 0.8.5",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.8.13"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c0279d09463a4695788a3622fd95443625f7be307422deba4b55dd491a9c7a1"
+checksum = "d4be1ce1274ddd7fdfac86e5ece1b225e9bba1f2327e20fbb30ee6b9cc1423fe"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.103",
 ]
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.8.13"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4feea540fc8233df2ad1156efd744b2075372f43a8f942a68b3b19c8a00e2c12"
+checksum = "01e92f3708ea4e0d9139001c86c051c538af0146944a2a9c7181753bd944bf57"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
  "const-hex",
  "heck 0.5.0",
- "indexmap",
+ "indexmap 2.6.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.103",
  "syn-solidity",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.8.13"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0ad281f3d1b613af814b66977ee698e443d4644a1510962d0241f26e0e53ae"
+checksum = "9afe1bd348a41f8c9b4b54dfb314886786d6201235b0b3f47198b9d910c86bb2"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
  "dunce",
  "heck 0.5.0",
+ "macro-string",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.89",
+ "syn 2.0.103",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "0.8.13"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96eff16c797438add6c37bb335839d015b186c5421ee5626f5559a7bfeb38ef5"
+checksum = "d6195df2acd42df92a380a8db6205a5c7b41282d0ce3f4c665ecf7911ac292f1"
 dependencies = [
  "serde",
- "winnow",
+ "winnow 0.7.11",
 ]
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.8.13"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff34e0682d6665da243a3e81da96f07a2dd50f7e64073e382b1a141f5a2a2f6"
+checksum = "6185e98a79cf19010722f48a74b5a65d153631d2f038cabd250f4b9e9813b8ad"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
  "alloy-sol-macro",
- "const-hex",
  "serde",
 ]
 
 [[package]]
 name = "alloy-transport"
-version = "0.6.4"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f99acddb34000d104961897dbb0240298e8b775a7efffb9fda2a1a3efedd65b3"
+checksum = "a712bdfeff42401a7dd9518f72f617574c36226a9b5414537fedc34350b73bf9"
 dependencies = [
  "alloy-json-rpc",
+ "alloy-primitives",
  "base64 0.22.1",
- "futures-util",
+ "derive_more",
+ "futures",
  "futures-utils-wasm",
+ "parking_lot",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.12",
  "tokio",
  "tower",
  "tracing",
@@ -614,9 +716,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.6.4"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dc013132e34eeadaa0add7e74164c1503988bfba8bae885b32e0918ba85a8a6"
+checksum = "7ea5a76d7f2572174a382aedf36875bedf60bcc41116c9f031cf08040703a2dc"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -629,9 +731,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "0.6.4"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063edc0660e81260653cc6a95777c29d54c2543a668aa5da2359fb450d25a1ba"
+checksum = "606af17a7e064d219746f6d2625676122c79d78bf73dfe746d6db9ecd7dbcb85"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -650,9 +752,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "0.6.4"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd170e600801116d5efe64f74a4fc073dbbb35c807013a7d0a388742aeebba0"
+checksum = "e0c6f9b37cd8d44aab959613966cc9d4d7a9b429c575cec43b3e5b46ea109a79"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -664,6 +766,22 @@ dependencies = [
  "tokio-tungstenite",
  "tracing",
  "ws_stream_wasm",
+]
+
+[[package]]
+name = "alloy-trie"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "983d99aa81f586cef9dae38443245e585840fcf0fc58b09aee0b1f27aed1d500"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "arrayvec",
+ "derive_more",
+ "nybbles",
+ "serde",
+ "smallvec",
+ "tracing",
 ]
 
 [[package]]
@@ -850,7 +968,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -860,7 +978,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -874,6 +992,9 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "async-stream"
@@ -894,7 +1015,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -905,7 +1026,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -942,7 +1063,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -998,24 +1119,40 @@ checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.6.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative",
+]
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bitvec"
@@ -1040,9 +1177,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4378725facc195f1a538864863f6de233b500a8862747e7f165078a419d5e874"
+checksum = "4fd49896f12ac9b6dcd7a5998466b9b58263a695a3dd1ecc1aaca2e12a90b080"
 dependencies = [
  "cc",
  "glob",
@@ -1100,7 +1237,7 @@ checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1111,18 +1248,18 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.8.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "c-kzg"
-version = "1.0.3"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0307f72feab3300336fb803a57134159f6e20139af1357f36c54cb90d8e8928"
+checksum = "7318cfa722931cb5fe0838b98d3ce5621e75f6a6408abc21721d80de9223f2e4"
 dependencies = [
  "blst",
  "cc",
@@ -1196,7 +1333,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex_cryo",
- "strsim",
+ "strsim 0.10.0",
 ]
 
 [[package]]
@@ -1219,7 +1356,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1246,7 +1383,7 @@ dependencies = [
  "nom",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1272,7 +1409,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24f165e7b643266ea80cb858aed492ad9280e3e05ce24d4a99d7d7b889b6a4d9"
 dependencies = [
  "crossterm",
- "strum",
+ "strum 0.26.3",
  "strum_macros 0.26.4",
  "unicode-width 0.2.0",
 ]
@@ -1292,9 +1429,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.13.2"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487981fa1af147182687064d0a2c336586d337a606595ced9ffb0c685c250c73"
+checksum = "83e22e0ed40b96a48d3db274f72fd365bd78f67af39b6bbd47e8a15e1c6207ff"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1333,6 +1470,21 @@ checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
@@ -1395,7 +1547,7 @@ dependencies = [
  "bitflags",
  "crossterm_winapi",
  "parking_lot",
- "rustix",
+ "rustix 0.38.41",
  "winapi",
 ]
 
@@ -1429,7 +1581,7 @@ dependencies = [
  "hex",
  "mesc",
  "polars",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "tokio",
@@ -1447,7 +1599,7 @@ dependencies = [
  "futures",
  "governor",
  "heck 0.4.1",
- "indexmap",
+ "indexmap 2.6.0",
  "indicatif",
  "mesc",
  "polars",
@@ -1455,7 +1607,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "thousands",
  "tokio",
  "url",
@@ -1479,7 +1631,7 @@ dependencies = [
 name = "cryo_to_df"
 version = "0.3.2"
 dependencies = [
- "indexmap",
+ "indexmap 2.6.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -1492,7 +1644,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -1505,6 +1657,41 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.103",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1551,6 +1738,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+dependencies = [
+ "powerfmt",
+ "serde",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1563,22 +1760,22 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "1.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "1.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.103",
  "unicode-xid",
 ]
 
@@ -1611,7 +1808,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1642,15 +1839,19 @@ dependencies = [
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
+ "serdect",
  "signature",
  "spki",
 ]
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "elliptic-curve"
@@ -1665,8 +1866,9 @@ dependencies = [
  "generic-array",
  "group",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
+ "serdect",
  "subtle",
  "zeroize",
 ]
@@ -1686,7 +1888,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1697,12 +1899,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1751,12 +1953,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrlp"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce8dba4714ef14b8274c371879b175aa55b16b30f269663f19d576f380018dc4"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
+
+[[package]]
 name = "ff"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1767,7 +1980,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand",
+ "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
 ]
@@ -1799,9 +2012,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -1895,7 +2108,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1960,8 +2173,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -1991,7 +2216,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "quanta",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "spinning_top",
 ]
@@ -2003,7 +2228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2019,9 +2244,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -2080,10 +2305,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "hex-literal"
-version = "0.4.1"
+name = "hex-conservative"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "hmac"
@@ -2335,8 +2563,14 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.103",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -2376,7 +2610,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2384,6 +2618,17 @@ name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
 
 [[package]]
 name = "indexmap"
@@ -2516,6 +2761,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
+ "serdect",
  "sha2",
 ]
 
@@ -2610,9 +2856,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.165"
+version = "0.2.173"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb4d3d38eab6c5239a362fa8bae48c03baf980a6e7079f063942d563ef3533e"
+checksum = "d8cfeafaffdbc32176b64fb251369d52ea9f0a8fbc6f8759edffef7b525d64bb"
 
 [[package]]
 name = "libm"
@@ -2625,6 +2871,12 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -2650,9 +2902,9 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 dependencies = [
  "hashbrown 0.15.2",
 ]
@@ -2674,6 +2926,17 @@ checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "macro-string"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2708,7 +2971,7 @@ checksum = "d4effaaca264c057c870afd19cf7137ef000ca64fc7292d5a0634ce5ebbb6e27"
 dependencies = [
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2740,7 +3003,7 @@ checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi 0.3.9",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -2834,6 +3097,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2879,7 +3148,7 @@ checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2887,6 +3156,19 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "nybbles"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8983bb634df7248924ee0c4c3a749609b5abcb082c28fffe3254b3eb3602b307"
+dependencies = [
+ "alloy-rlp",
+ "const-hex",
+ "proptest",
+ "serde",
+ "smallvec",
+]
 
 [[package]]
 name = "object"
@@ -2899,9 +3181,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "openssl"
@@ -2926,7 +3208,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2971,7 +3253,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -3035,7 +3317,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 1.0.69",
  "ucd-trie",
 ]
 
@@ -3075,7 +3357,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -3104,7 +3386,7 @@ checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -3150,7 +3432,7 @@ version = "0.38.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f01006048a264047d6cba081fed8e11adbd69c15956f9e53185a9ac4a541853c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "polars-arrow",
  "polars-core",
  "polars-error",
@@ -3182,7 +3464,7 @@ dependencies = [
  "fast-float",
  "foreign_vec",
  "futures",
- "getrandom",
+ "getrandom 0.2.15",
  "hashbrown 0.14.5",
  "itoa",
  "itoap",
@@ -3240,7 +3522,7 @@ dependencies = [
  "comfy-table",
  "either",
  "hashbrown 0.14.5",
- "indexmap",
+ "indexmap 2.6.0",
  "num-traits",
  "once_cell",
  "polars-arrow",
@@ -3248,12 +3530,12 @@ dependencies = [
  "polars-error",
  "polars-row",
  "polars-utils",
- "rand",
+ "rand 0.8.5",
  "rand_distr",
  "rayon",
  "regex",
  "smartstring",
- "thiserror",
+ "thiserror 1.0.69",
  "version_check",
  "xxhash-rust",
 ]
@@ -3267,7 +3549,7 @@ dependencies = [
  "polars-arrow-format",
  "regex",
  "simdutf8",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3318,7 +3600,7 @@ dependencies = [
  "chrono",
  "fallible-streaming-iterator",
  "hashbrown 0.14.5",
- "indexmap",
+ "indexmap 2.6.0",
  "itoa",
  "num-traits",
  "polars-arrow",
@@ -3368,7 +3650,7 @@ dependencies = [
  "either",
  "hashbrown 0.14.5",
  "hex",
- "indexmap",
+ "indexmap 2.6.0",
  "jsonpath_lib_polars_vendor",
  "memchr",
  "num-traits",
@@ -3487,7 +3769,7 @@ dependencies = [
  "polars-error",
  "polars-lazy",
  "polars-plan",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "sqlparser",
@@ -3522,7 +3804,7 @@ dependencies = [
  "ahash",
  "bytemuck",
  "hashbrown 0.14.5",
- "indexmap",
+ "indexmap 2.6.0",
  "num-traits",
  "once_cell",
  "polars-error",
@@ -3538,6 +3820,12 @@ name = "portable-atomic"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -3596,7 +3884,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -3610,17 +3898,17 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.5.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
+checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
 dependencies = [
  "bit-set",
  "bit-vec",
  "bitflags",
  "lazy_static",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.9.1",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -3688,7 +3976,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -3701,7 +3989,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -3713,7 +4001,7 @@ dependencies = [
  "polars",
  "polars-core",
  "pyo3",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3726,7 +4014,7 @@ dependencies = [
  "libc",
  "once_cell",
  "raw-cpuid",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "web-sys",
  "winapi",
 ]
@@ -3747,6 +4035,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3759,8 +4053,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+ "serde",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
  "serde",
 ]
 
@@ -3771,7 +4076,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -3780,7 +4095,17 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
+ "serde",
 ]
 
 [[package]]
@@ -3790,16 +4115,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
 name = "rand_xorshift"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -3863,7 +4188,7 @@ checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -3952,7 +4277,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "spin",
  "untrusted",
@@ -3971,21 +4296,24 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.12.3"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c3cc4c2511671f327125da14133d0c5c5d137f006a1017a16f557bc85b16286"
+checksum = "11256b5fe8c68f56ac6f39ef0720e592f33d2367a4782740d9c9142e889c7fb4"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
  "ark-ff 0.4.2",
  "bytes",
- "fastrlp",
+ "fastrlp 0.3.1",
+ "fastrlp 0.4.0",
  "num-bigint",
+ "num-integer",
  "num-traits",
  "parity-scale-codec",
  "primitive-types",
  "proptest",
- "rand",
+ "rand 0.8.5",
+ "rand 0.9.1",
  "rlp",
  "ruint-macro",
  "serde",
@@ -4007,9 +4335,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc-hex"
@@ -4044,8 +4372,21 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.14",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4122,14 +4463,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "schnellru"
-version = "0.2.3"
+name = "schemars"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a8ef13a93c54d20580de1e5c413e624e53121d42fc7e2c11d10ef7f8b02367"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
 dependencies = [
- "ahash",
- "cfg-if",
- "hashbrown 0.13.2",
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -4148,8 +4490,30 @@ dependencies = [
  "der",
  "generic-array",
  "pkcs8",
+ "serdect",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.8.5",
+ "secp256k1-sys",
+ "serde",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -4228,7 +4592,7 @@ checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -4237,7 +4601,7 @@ version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
 dependencies = [
- "indexmap",
+ "indexmap 2.6.0",
  "itoa",
  "memchr",
  "ryu",
@@ -4253,6 +4617,47 @@ dependencies = [
  "form_urlencoded",
  "itoa",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf65a400f8f66fb7b0552869ad70157166676db75ed8181f8104ea91cf9d0b42"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.6.0",
+ "schemars",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81679d9ed988d5e9a5e6531dc3f2c28efbd639cbd1dfb628df08edea6004da77"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
+]
+
+[[package]]
+name = "serdect"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+dependencies = [
+ "base16ct",
  "serde",
 ]
 
@@ -4311,7 +4716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4321,7 +4726,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0228a564470f81724e30996bbc2b171713b37b15254a6440c7e2d5449b95691"
 dependencies = [
  "ahash",
- "getrandom",
+ "getrandom 0.2.15",
  "halfbrown",
  "lexical-core",
  "once_cell",
@@ -4358,6 +4763,9 @@ name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smartstring"
@@ -4460,12 +4868,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
+name = "strum"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
 dependencies = [
- "strum_macros 0.26.4",
+ "strum_macros 0.27.1",
 ]
 
 [[package]]
@@ -4478,7 +4898,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.89",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -4491,7 +4911,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.89",
+ "syn 2.0.103",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -4513,9 +4946,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.89"
+version = "2.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e"
+checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4524,14 +4957,14 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.8.13"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdaa7b9e815582ba343a20c66627437cf45f1c6fba7f69772cbfd1358c7e197"
+checksum = "14c8c8f496c33dc6343dac05b4be8d9e0bca180a4caa81d7b8416b10cc2273cd"
 dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -4557,7 +4990,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -4594,14 +5027,14 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
- "cfg-if",
  "fastrand",
+ "getrandom 0.3.3",
  "once_cell",
- "rustix",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -4611,7 +5044,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -4622,7 +5064,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.103",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -4638,6 +5091,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
+]
+
+[[package]]
+name = "time"
+version = "0.3.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+
+[[package]]
+name = "time-macros"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -4683,7 +5167,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -4721,9 +5205,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.24.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
@@ -4760,9 +5244,9 @@ version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap",
+ "indexmap 2.6.0",
  "toml_datetime",
- "winnow",
+ "winnow 0.6.20",
 ]
 
 [[package]]
@@ -4810,7 +5294,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -4823,6 +5307,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "futures",
+ "futures-task",
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4830,21 +5326,20 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.24.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
 dependencies = [
- "byteorder",
  "bytes",
  "data-encoding",
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.9.1",
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror",
+ "thiserror 2.0.12",
  "utf-8",
 ]
 
@@ -4970,7 +5465,7 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -5028,6 +5523,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5049,7 +5553,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.103",
  "wasm-bindgen-shared",
 ]
 
@@ -5083,7 +5587,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.103",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5372,6 +5876,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5396,7 +5918,7 @@ dependencies = [
  "pharos",
  "rustc_version 0.4.1",
  "send_wrapper",
- "thiserror",
+ "thiserror 1.0.69",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -5437,7 +5959,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.103",
  "synstructure",
 ]
 
@@ -5459,7 +5981,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -5479,7 +6001,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.103",
  "synstructure",
 ]
 
@@ -5500,7 +6022,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -5522,7 +6044,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.89",
+ "syn 2.0.103",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ cryo_cli = { version = "0.3.2", path = "./crates/cli" }
 cryo_freeze = { version = "0.3.2", path = "./crates/freeze" }
 cryo_to_df = { version = "0.3.2", path = "./crates/to_df" }
 
-alloy = { version = "0.6.4", features = [
+alloy = { version = "1.0.9", features = [
     "full",
     "rpc-types-trace",
     "provider-ws",

--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -322,7 +322,7 @@ fn get_after_str() -> String {
       <white><bold>cryo help</bold></white>"#
     );
     let post_subcommands = " <DATASET(S)>         display info about a dataset";
-    format!("{}{}{}", header, subcommands, post_subcommands)
+    format!("{header}{subcommands}{post_subcommands}")
 }
 
 fn get_datatype_help() -> &'static str {

--- a/crates/cli/src/parse/blocks.rs
+++ b/crates/cli/src/parse/blocks.rs
@@ -20,7 +20,7 @@ pub(crate) async fn parse_blocks(
         for path in files {
             let column = if path.contains(':') {
                 path.split(':')
-                    .last()
+                    .next_back()
                     .ok_or(ParseError::ParseError("could not parse txs path column".to_string()))?
             } else {
                 "block_number"
@@ -498,11 +498,11 @@ mod tests {
                     );
                 }
                 BlockInputTest::WithoutMock((inputs, expected)) => {
-                    println!("RES {:?}", res);
-                    println!("inputs {:?}", inputs);
-                    println!("EXPECTED {:?}", expected);
+                    println!("RES {res:?}");
+                    println!("inputs {inputs:?}");
+                    println!("EXPECTED {expected:?}");
                     let actual = block_input_test_executor(inputs, expected, source.clone()).await;
-                    println!("ACTUAL {:?}", actual);
+                    println!("ACTUAL {actual:?}");
                     assert_eq!(actual, res);
                 }
             }
@@ -518,8 +518,8 @@ mod tests {
         assert_eq!(block_chunks.len(), expected.len());
         for (i, block_chunk) in block_chunks.iter().enumerate() {
             let expected_chunk = &expected[i];
-            println!("BLOCK_CHUNK {:?}", block_chunk);
-            println!("EXCPECTED_CHUNK {:?}", expected_chunk);
+            println!("BLOCK_CHUNK {block_chunk:?}");
+            println!("EXCPECTED_CHUNK {expected_chunk:?}");
             match expected_chunk {
                 BlockChunk::Numbers(expected_block_numbers) => {
                     assert!(matches!(block_chunk, BlockChunk::Numbers { .. }));

--- a/crates/cli/src/parse/blocks.rs
+++ b/crates/cli/src/parse/blocks.rs
@@ -395,8 +395,8 @@ mod tests {
     use std::path::PathBuf;
 
     use alloy::{
-        providers::{IpcConnect, ProviderBuilder},
-        transports::ipc::MockIpcServer,
+        providers::{Provider, ProviderBuilder},
+        transports::ipc::{IpcConnect, MockIpcServer},
     };
 
     use super::*;
@@ -412,7 +412,7 @@ mod tests {
         mock_ipc_path: PathBuf,
     ) {
         let ipc = IpcConnect::new(mock_ipc_path);
-        let provider = ProviderBuilder::new().on_ipc(ipc).await.unwrap().boxed();
+        let provider = ProviderBuilder::new().connect_ipc(ipc).await.unwrap().erased();
         let source = Source {
             provider,
             semaphore: Arc::new(None),
@@ -478,7 +478,7 @@ mod tests {
         mock_ipc_path: PathBuf,
     ) {
         let ipc = IpcConnect::new(mock_ipc_path);
-        let provider = ProviderBuilder::new().on_ipc(ipc).await.unwrap().boxed();
+        let provider = ProviderBuilder::new().connect_ipc(ipc).await.unwrap().erased();
         let source = Arc::new(Source {
             provider,
             chain_id: 1,
@@ -554,8 +554,11 @@ mod tests {
         tests: Vec<(BlockNumberTest<'_>, bool)>,
         mock_ipc_path: PathBuf,
     ) {
-        let provider =
-            ProviderBuilder::new().on_ipc(IpcConnect::new(mock_ipc_path)).await.unwrap().boxed();
+        let provider = ProviderBuilder::new()
+            .connect_ipc(IpcConnect::new(mock_ipc_path))
+            .await
+            .unwrap()
+            .erased();
         let source = Source {
             provider,
             semaphore: Arc::new(None),

--- a/crates/cli/src/parse/file_output.rs
+++ b/crates/cli/src/parse/file_output.rs
@@ -12,7 +12,7 @@ pub(crate) fn parse_file_output(args: &Args, source: &Source) -> Result<FileOutp
     })?;
     match fs::create_dir_all(&output_dir) {
         Ok(_) => {}
-        Err(e) => return Err(ParseError::ParseError(format!("Error creating directory: {}", e))),
+        Err(e) => return Err(ParseError::ParseError(format!("Error creating directory: {e}"))),
     };
 
     let label = &args.label;

--- a/crates/cli/src/parse/partitions.rs
+++ b/crates/cli/src/parse/partitions.rs
@@ -105,7 +105,7 @@ pub(crate) async fn parse_partitions(
     };
     let mut partitions = chunk
         .partition_with_labels(labels, partition_by.clone())
-        .map_err(|e| ParseError::ParseError(format!("could not partition labels ({})", e)))?;
+        .map_err(|e| ParseError::ParseError(format!("could not partition labels ({e})")))?;
 
     match args.chunk_order.as_deref() {
         None => {}

--- a/crates/cli/src/parse/schemas.rs
+++ b/crates/cli/src/parse/schemas.rs
@@ -64,8 +64,7 @@ pub(crate) fn parse_schemas(
                 .map(|schema| (*datatype, schema))
                 .map_err(|e| {
                     ParseError::ParseError(format!(
-                        "Failed to get schema for datatype: {:?}, {:?}",
-                        datatype, e
+                        "Failed to get schema for datatype: {datatype:?}, {e:?}"
                     ))
                 })
         })
@@ -100,7 +99,7 @@ fn parse_u256_types(args: &Args) -> Result<Vec<U256Type>, ParseError> {
                         "u32" | "uint32" => Ok(U256Type::U32),
                         "u64" | "uint64" => Ok(U256Type::U64),
                         "decimal128" | "d128" => Ok(U256Type::Decimal128),
-                        _ => Err(ParseError::ParseError(format!("invalid u256 type: {}", raw))),
+                        _ => Err(ParseError::ParseError(format!("invalid u256 type: {raw}"))),
                     }
                 })
                 .collect()
@@ -129,8 +128,7 @@ fn ensure_included_columns(
     }
     if !unknown_columns.is_empty() {
         return Err(ParseError::ParseError(format!(
-            "datatypes do not support these columns: {:?}",
-            unknown_columns
+            "datatypes do not support these columns: {unknown_columns:?}"
         )))
     }
     Ok(())
@@ -157,8 +155,7 @@ fn ensure_excluded_columns(
     }
     if !unknown_columns.is_empty() {
         return Err(ParseError::ParseError(format!(
-            "datatypes do not support these columns: {:?}",
-            unknown_columns
+            "datatypes do not support these columns: {unknown_columns:?}"
         )))
     }
     Ok(())

--- a/crates/cli/src/parse/source.rs
+++ b/crates/cli/src/parse/source.rs
@@ -1,14 +1,13 @@
-use std::env;
+use std::{env, sync::Arc};
 
 use crate::args::Args;
 use alloy::{
-    providers::{Provider, ProviderBuilder, RootProvider},
-    rpc::client::{BuiltInConnectionString, ClientBuilder, RpcClient},
-    transports::{layers::RetryBackoffLayer, BoxTransport},
+    providers::{Provider, ProviderBuilder},
+    rpc::client::ClientBuilder,
+    transports::layers::RetryBackoffLayer,
 };
 use cryo_freeze::{ParseError, Source, SourceLabels};
 use governor::{Quota, RateLimiter};
-use polars::prelude::*;
 use std::num::NonZeroU32;
 
 pub(crate) async fn parse_source(args: &Args) -> Result<Source, ParseError> {
@@ -19,14 +18,12 @@ pub(crate) async fn parse_source(args: &Args) -> Result<Source, ParseError> {
         args.initial_backoff,
         args.compute_units_per_second,
     );
-    let connect: BuiltInConnectionString = rpc_url.parse().map_err(ParseError::ProviderError)?;
-    let client: RpcClient<BoxTransport> = ClientBuilder::default()
+    let client = ClientBuilder::default()
         .layer(retry_layer)
-        .connect_boxed(connect)
+        .connect(&rpc_url)
         .await
-        .map_err(ParseError::ProviderError)?
-        .boxed();
-    let provider: RootProvider<BoxTransport> = ProviderBuilder::default().on_client(client);
+        .map_err(ParseError::ProviderError)?;
+    let provider = ProviderBuilder::default().connect_client(client).erased();
     let chain_id = provider.get_chain_id().await.map_err(ParseError::ProviderError)?;
     let rate_limiter = match args.requests_per_second {
         Some(rate_limit) => match (NonZeroU32::new(1), NonZeroU32::new(rate_limit)) {

--- a/crates/cli/src/parse/source.rs
+++ b/crates/cli/src/parse/source.rs
@@ -76,7 +76,7 @@ pub(crate) fn parse_rpc_url(args: &Args) -> Result<String, ParseError> {
         match endpoint {
             Ok(endpoint) => endpoint.map(|endpoint| endpoint.url),
             Err(e) => {
-                eprintln!("Could not load MESC data: {}", e);
+                eprintln!("Could not load MESC data: {e}");
                 None
             }
         }

--- a/crates/cli/src/parse/timestamps.rs
+++ b/crates/cli/src/parse/timestamps.rs
@@ -24,7 +24,7 @@ pub(crate) async fn parse_timestamps(
         for path in files {
             let column = if path.contains(':') {
                 path.split(':')
-                    .last()
+                    .next_back()
                     .ok_or(ParseError::ParseError("could not parse txs path column".to_string()))?
             } else {
                 "timestamp"

--- a/crates/cli/src/parse/timestamps.rs
+++ b/crates/cli/src/parse/timestamps.rs
@@ -325,9 +325,9 @@ mod tests {
     use std::num::NonZeroU32;
 
     use alloy::{
-        providers::ProviderBuilder,
-        rpc::client::{BuiltInConnectionString, ClientBuilder, RpcClient},
-        transports::{layers::RetryBackoffLayer, BoxTransport},
+        providers::{Provider, ProviderBuilder},
+        rpc::client::ClientBuilder,
+        transports::layers::RetryBackoffLayer,
     };
     use governor::{Quota, RateLimiter};
 
@@ -345,16 +345,13 @@ mod tests {
         let max_concurrent_requests = 100;
         let retry_layer =
             RetryBackoffLayer::new(max_retry, initial_backoff, compute_units_per_second);
-        let connect: BuiltInConnectionString =
-            rpc_url.parse().map_err(ParseError::ProviderError).unwrap();
-        let client: RpcClient<BoxTransport> = ClientBuilder::default()
+        let client = ClientBuilder::default()
             .layer(retry_layer)
-            .connect_boxed(connect)
+            .connect(&rpc_url)
             .await
             .map_err(ParseError::ProviderError)
-            .unwrap()
-            .boxed();
-        let provider = ProviderBuilder::default().on_client(client);
+            .unwrap();
+        let provider = ProviderBuilder::default().connect_client(client).erased();
         let quota = Quota::per_second(NonZeroU32::new(15).unwrap())
             .allow_burst(NonZeroU32::new(1).unwrap());
         let rate_limiter = Some(RateLimiter::direct(quota));

--- a/crates/cli/src/run.rs
+++ b/crates/cli/src/run.rs
@@ -114,7 +114,7 @@ fn print_syntax_help() {
                                      (default column name is <white><bold>transaction_hash</bold></white>)
 - can use multiple parquet files     <white><bold>--txs ./path/to/ethereum__logs*.parquet</bold></white>"#
     );
-    println!("{}", content);
+    println!("{content}");
 }
 
 /// Handle detailed help by parsing schemas and printing dataset information.
@@ -129,7 +129,7 @@ fn handle_detailed_help(args: args::Args) -> Result<(), CollectError> {
         if let Some(schema) = schemas.get(&datatype) {
             cryo_freeze::print_dataset_info(datatype, schema);
         } else {
-            return Err(err(format!("missing schema for datatype: {:?}", datatype).as_str()));
+            return Err(err(format!("missing schema for datatype: {datatype:?}").as_str()));
         }
     }
 

--- a/crates/freeze/build.rs
+++ b/crates/freeze/build.rs
@@ -4,7 +4,7 @@ fn main() {
     let git_description =
         get_git_description().unwrap_or_else(|_| env!("CARGO_PKG_VERSION").to_string());
 
-    println!("cargo:rustc-env=GIT_DESCRIPTION={}", git_description);
+    println!("cargo:rustc-env=GIT_DESCRIPTION={git_description}");
 }
 
 fn get_git_description() -> Result<String, std::io::Error> {
@@ -18,6 +18,6 @@ fn get_git_description() -> Result<String, std::io::Error> {
 
         Ok(description)
     } else {
-        Err(std::io::Error::new(std::io::ErrorKind::Other, "Git command failed"))
+        Err(std::io::Error::other("Git command failed"))
     }
 }

--- a/crates/freeze/src/datasets/address_appearances.rs
+++ b/crates/freeze/src/datasets/address_appearances.rs
@@ -114,7 +114,7 @@ impl CollectByTransaction for AddressAppearances {
 fn name(log: &Log) -> Option<&'static str> {
     let event = log.topic0().unwrap();
     if event == *ERC20::Transfer::SIGNATURE_HASH {
-        if log.data().data.len() > 0 {
+        if !log.data().data.is_empty() {
             Some("erc20_transfer")
         } else if log.topics().len() == 4 {
             Some("erc721_transfer")

--- a/crates/freeze/src/datasets/erc721_transfers.rs
+++ b/crates/freeze/src/datasets/erc721_transfers.rs
@@ -71,7 +71,7 @@ impl CollectByBlock for Erc721Transfers {
         let filter = Filter { topics, ..request.ethers_log_filter()? };
         let logs = source.get_logs(&filter).await?;
 
-        Ok(logs.into_iter().filter(|x| x.topics().len() == 4 && x.data().data.len() == 0).collect())
+        Ok(logs.into_iter().filter(|x| x.topics().len() == 4 && x.data().data.is_empty()).collect())
     }
 
     fn transform(response: Self::Response, columns: &mut Self, query: &Arc<Query>) -> R<()> {
@@ -97,7 +97,7 @@ impl CollectByTransaction for Erc721Transfers {
 
 fn is_erc721_transfer(log: &Log) -> bool {
     log.topics().len() == 4 &&
-        log.data().data.len() == 0 &&
+        log.data().data.is_empty() &&
         log.topics()[0] == ERC721::Transfer::SIGNATURE_HASH
 }
 

--- a/crates/freeze/src/datasets/logs.rs
+++ b/crates/freeze/src/datasets/logs.rs
@@ -136,7 +136,7 @@ fn process_logs(logs: Vec<Log>, columns: &mut Logs, schema: &Table) -> R<()> {
             if let (Some(decoder), Some(indexed_keys), Some(body_keys)) =
                 (&schema.log_decoder, &indexed_keys, &body_keys)
             {
-                match decoder.event.decode_log(&log.inner.data, true) {
+                match decoder.event.decode_log(&log.inner.data) {
                     Ok(log) => {
                         // for param in log.indexed {
                         //     if decode_keys.contains(param.name.as_str()) {

--- a/crates/freeze/src/datasets/transactions.rs
+++ b/crates/freeze/src/datasets/transactions.rs
@@ -255,7 +255,7 @@ pub(crate) fn process_transaction(
     }
     // in alloy eip2718_encoded_length is rlp_encoded_length
     store!(schema, columns, n_rlp_bytes, tx.inner.eip2718_encoded_length() as u32);
-    store!(schema, columns, gas_used, receipt.as_ref().map(|r| r.gas_used as u64));
+    store!(schema, columns, gas_used, receipt.as_ref().map(|r| r.gas_used));
     // store!(schema, columns, gas_price, Some(receipt.unwrap().effective_gas_price as u64));
     store!(schema, columns, gas_price, gas_price);
     store!(schema, columns, transaction_type, tx.inner.tx_type() as u32);
@@ -310,9 +310,9 @@ fn tx_success(tx: &Transaction, receipt: &Option<TransactionReceipt>) -> R<bool>
         if let Some(r) = receipt {
             Ok(r.gas_used == 0)
         } else {
-            return Err(err("could not determine status of transaction"))
+            Err(err("could not determine status of transaction"))
         }
     } else {
-        return Err(err("could not determine status of transaction"))
+        Err(err("could not determine status of transaction"))
     }
 }

--- a/crates/freeze/src/freeze.rs
+++ b/crates/freeze/src/freeze.rs
@@ -157,7 +157,7 @@ async fn freeze_partitions(
                 completed.push(partition)
             }
             Ok((partition, Err(e))) => errored.push((Some(partition), e)),
-            Err(e) => errored.push((None, err(format!("error joining chunks: {:?}", e).as_str()))),
+            Err(e) => errored.push((None, err(format!("error joining chunks: {e:?}").as_str()))),
         }
     }
 

--- a/crates/freeze/src/types/chunks/number_chunk.rs
+++ b/crates/freeze/src/types/chunks/number_chunk.rs
@@ -16,7 +16,7 @@ impl ChunkData for NumberChunk {
     type Inner = u64;
 
     fn format_item(value: Self::Inner) -> Result<String, ChunkError> {
-        Ok(format!("{:0>8}", value))
+        Ok(format!("{value:0>8}"))
     }
 
     fn size(&self) -> u64 {

--- a/crates/freeze/src/types/datatypes/multi.rs
+++ b/crates/freeze/src/types/datatypes/multi.rs
@@ -62,6 +62,6 @@ impl MultiDatatype {
 
     /// name
     pub fn name(&self) -> String {
-        format!("{}", heck::AsSnakeCase(format!("{:?}", self)))
+        format!("{}", heck::AsSnakeCase(format!("{self:?}")))
     }
 }

--- a/crates/freeze/src/types/datatypes/scalar.rs
+++ b/crates/freeze/src/types/datatypes/scalar.rs
@@ -68,6 +68,6 @@ impl std::str::FromStr for Datatype {
     fn from_str(s: &str) -> Result<Datatype, ParseError> {
         let mut map = Datatype::alias_map()?;
         map.remove(s)
-            .ok_or_else(|| ParseError::ParseError(format!("no datatype matches input: {}", s)))
+            .ok_or_else(|| ParseError::ParseError(format!("no datatype matches input: {s}")))
     }
 }

--- a/crates/freeze/src/types/decoders/log_decoder.rs
+++ b/crates/freeze/src/types/decoders/log_decoder.rs
@@ -62,8 +62,7 @@ impl LogDecoder {
             .collect();
 
         for log in logs {
-            match self.event.decode_log_parts(log.topics().to_vec(), log.data().data.as_ref(), true)
-            {
+            match self.event.decode_log_parts(log.topics().to_vec(), log.data().data.as_ref()) {
                 Ok(decoded) => {
                     for (idx, param) in decoded.indexed.into_iter().enumerate() {
                         map.entry(indexed_keys[idx].clone()).or_default().push(param);

--- a/crates/freeze/src/types/decoders/log_decoder.rs
+++ b/crates/freeze/src/types/decoders/log_decoder.rs
@@ -26,8 +26,8 @@ impl LogDecoder {
         match Event::parse(&event_signature) {
             Ok(event) => Ok(Self { event, raw: event_signature.clone() }),
             Err(e) => {
-                let err = format!("incorrectly formatted event {} (expect something like event Transfer(address indexed from, address indexed to, uint256 amount) err: {}", event_signature, e);
-                eprintln!("{}", err);
+                let err = format!("incorrectly formatted event {event_signature} (expect something like event Transfer(address indexed from, address indexed to, uint256 amount) err: {e}");
+                eprintln!("{err}");
                 Err(err)
             }
         }
@@ -71,7 +71,7 @@ impl LogDecoder {
                         map.entry(body_keys[idx].clone()).or_default().push(param);
                     }
                 }
-                Err(e) => eprintln!("error parsing log: {:?}", e),
+                Err(e) => eprintln!("error parsing log: {e:?}"),
             }
         }
         map
@@ -101,7 +101,7 @@ impl LogDecoder {
             match token {
                 DynSolValue::Address(a) => match column_encoding {
                     ColumnEncoding::Binary => bytes.push(a.to_vec()),
-                    ColumnEncoding::Hex => hexes.push(format!("{:?}", a)),
+                    ColumnEncoding::Hex => hexes.push(format!("{a:?}")),
                 },
                 DynSolValue::FixedBytes(b, _) => match column_encoding {
                     ColumnEncoding::Binary => bytes.push(b.to_vec()),
@@ -132,12 +132,12 @@ impl LogDecoder {
                 DynSolValue::Function(_) => {}
             }
         }
-        let mixed_length_err = format!("could not parse column {}, mixed type", name);
+        let mixed_length_err = format!("could not parse column {name}, mixed type");
         let mixed_length_err = mixed_length_err.as_str();
 
         // check each vector, see if it contains any values, if it does, check if it's the same
         // length as the input data and map to a series
-        let name = format!("event__{}", name);
+        let name = format!("event__{name}");
         if !ints.is_empty() {
             Ok(vec![Series::new(name.as_str(), ints)])
         } else if !i256s.is_empty() {

--- a/crates/freeze/src/types/mod.rs
+++ b/crates/freeze/src/types/mod.rs
@@ -59,7 +59,7 @@ pub use datatypes::*;
 pub use files::{ColumnEncoding, FileFormat, FileOutput, SubDir};
 pub use queries::{Query, QueryLabels, TimeDimension};
 pub use schemas::{ColumnType, SchemaFunctions, Schemas, Table, U256Type};
-pub use sources::{Fetcher, RateLimiter, Source, SourceLabels};
+pub use sources::{RateLimiter, Source, SourceLabels};
 // pub(crate) use summaries::FreezeSummaryAgg;
 // pub use summaries::{FreezeChunkSummary, FreezeSummary};
 pub use summaries::{print_all_datasets, print_dataset_info, FreezeSummary};

--- a/crates/freeze/src/types/partitions.rs
+++ b/crates/freeze/src/types/partitions.rs
@@ -114,7 +114,7 @@ impl std::fmt::Display for Dim {
             Dim::Topic2 => "topic2",
             Dim::Topic3 => "topic3",
         };
-        write!(f, "{}", as_str)
+        write!(f, "{as_str}")
     }
 }
 

--- a/crates/freeze/src/types/sources.rs
+++ b/crates/freeze/src/types/sources.rs
@@ -342,10 +342,7 @@ impl Source {
         kind: BlockTransactionsKind,
     ) -> Result<Option<Block>> {
         let _permit = self.permit_request().await;
-        let block_result = match kind {
-            BlockTransactionsKind::Full => self.provider.get_block(block_num.into()).await,
-            BlockTransactionsKind::Hashes => self.provider.get_block(block_num.into()).await,
-        };
+        let block_result = self.provider.get_block(block_num.into()).kind(kind).await;
         Self::map_err(block_result)
     }
 
@@ -356,10 +353,7 @@ impl Source {
         kind: BlockTransactionsKind,
     ) -> Result<Option<Block>> {
         let _permit = self.permit_request().await;
-        let block_result = match kind {
-            BlockTransactionsKind::Full => self.provider.get_block(block_hash.into()).await,
-            BlockTransactionsKind::Hashes => self.provider.get_block(block_hash.into()).await,
-        };
+        let block_result = self.provider.get_block(block_hash.into()).kind(kind).await;
         Self::map_err(block_result)
     }
 

--- a/crates/freeze/src/types/sources.rs
+++ b/crates/freeze/src/types/sources.rs
@@ -512,12 +512,12 @@ impl Source {
             ..Default::default()
         };
         let _permit = self.permit_request().await;
-        if block_number.is_some() {
+        if let Some(bn) = block_number {
             Self::map_err(
                 self.provider
                     .trace_call(&transaction)
                     .trace_types(trace_type.clone())
-                    .block_id(block_number.unwrap().into())
+                    .block_id(bn.into())
                     .await,
             )
         } else {
@@ -587,15 +587,13 @@ impl Source {
                     GethTrace::JS(value) => calls.push(value),
                     _ => {
                         return Err(CollectError::CollectError(format!(
-                            "invalid trace result in tx {:?}",
-                            tx_hash
+                            "invalid trace result in tx {tx_hash:?}"
                         )))
                     }
                 },
                 TraceResult::Error { error, tx_hash } => {
                     return Err(CollectError::CollectError(format!(
-                        "invalid trace result in tx {:?}: {}",
-                        tx_hash, error
+                        "invalid trace result in tx {tx_hash:?}: {error}"
                     )))
                 }
             }
@@ -620,15 +618,13 @@ impl Source {
                     GethTrace::Default(frame) => calls.push(frame),
                     _ => {
                         return Err(CollectError::CollectError(format!(
-                            "invalid trace result in tx {:?}",
-                            tx_hash
+                            "invalid trace result in tx {tx_hash:?}"
                         )))
                     }
                 },
                 TraceResult::Error { error, tx_hash } => {
                     return Err(CollectError::CollectError(format!(
-                        "inalid trace result in tx {:?}: {}",
-                        tx_hash, error
+                        "inalid trace result in tx {tx_hash:?}: {error}"
                     )));
                 }
             }
@@ -660,15 +656,13 @@ impl Source {
                     GethTrace::NoopTracer(_) => {}
                     _ => {
                         return Err(CollectError::CollectError(format!(
-                            "invalid trace result in tx {:?}",
-                            tx_hash
+                            "invalid trace result in tx {tx_hash:?}"
                         )))
                     }
                 },
                 TraceResult::Error { error, tx_hash } => {
                     return Err(CollectError::CollectError(format!(
-                        "invalid trace result in tx {:?}: {}",
-                        tx_hash, error
+                        "invalid trace result in tx {tx_hash:?}: {error}"
                     )));
                 }
             }
@@ -698,15 +692,13 @@ impl Source {
                     GethTrace::PreStateTracer(PreStateFrame::Default(frame)) => calls.push(frame.0),
                     _ => {
                         return Err(CollectError::CollectError(format!(
-                            "invalid trace result in tx {:?}",
-                            tx_hash
+                            "invalid trace result in tx {tx_hash:?}"
                         )))
                     }
                 },
                 TraceResult::Error { error, tx_hash } => {
                     return Err(CollectError::CollectError(format!(
-                        "invalid trace result in tx {:?}: {}",
-                        tx_hash, error
+                        "invalid trace result in tx {tx_hash:?}: {error}"
                     )));
                 }
             }
@@ -741,15 +733,13 @@ impl Source {
                     GethTrace::CallTracer(frame) => calls.push(frame),
                     _ => {
                         return Err(CollectError::CollectError(format!(
-                            "invalid trace result in tx {:?}",
-                            tx_hash
+                            "invalid trace result in tx {tx_hash:?}"
                         )))
                     }
                 },
                 TraceResult::Error { error, tx_hash } => {
                     return Err(CollectError::CollectError(format!(
-                        "invalid trace result in tx {:?}: {}",
-                        tx_hash, error
+                        "invalid trace result in tx {tx_hash:?}: {error}"
                     )));
                 }
             }
@@ -787,17 +777,15 @@ impl Source {
                         diffs.push(diff);
                     }
                     _ => {
-                        println!("{:?}", result);
+                        println!("{result:?}");
                         return Err(CollectError::CollectError(format!(
-                            "invalid trace result in tx {:?}",
-                            tx_hash
+                            "invalid trace result in tx {tx_hash:?}"
                         )));
                     }
                 },
                 TraceResult::Error { error, tx_hash } => {
                     return Err(CollectError::CollectError(format!(
-                        "invalid trace result in tx {:?}: {}",
-                        tx_hash, error
+                        "invalid trace result in tx {tx_hash:?}: {error}"
                     )));
                 }
             }

--- a/crates/freeze/src/types/summaries.rs
+++ b/crates/freeze/src/types/summaries.rs
@@ -52,7 +52,7 @@ pub fn print_all_datasets() {
     println!();
     print_header("dataset group names");
     for datatype in MultiDatatype::variants().iter() {
-        let name = heck::AsSnakeCase(format!("{:?}", datatype)).to_string();
+        let name = heck::AsSnakeCase(format!("{datatype:?}")).to_string();
         let subtypes =
             datatype.datatypes().iter().map(|dt| dt.name()).collect::<Vec<_>>().join(", ");
         print_bullet(name, subtypes)
@@ -74,7 +74,7 @@ pub fn print_dataset_info(datatype: Datatype, schema: &Table) {
     let required_parameters = datatype
         .required_parameters()
         .iter()
-        .map(|x| format!("{}", x))
+        .map(|x| format!("{x}"))
         .collect::<Vec<_>>()
         .join(", ");
     let required_parameters =
@@ -84,7 +84,7 @@ pub fn print_dataset_info(datatype: Datatype, schema: &Table) {
     let optional_parameters = datatype
         .optional_parameters()
         .iter()
-        .map(|x| format!("{}", x))
+        .map(|x| format!("{x}"))
         .collect::<Vec<_>>()
         .join(", ");
     let optional_parameters =
@@ -113,21 +113,21 @@ pub fn print_dataset_info(datatype: Datatype, schema: &Table) {
 pub(crate) fn print_header<A: AsRef<str>>(header: A) {
     let header_str = header.as_ref().white().bold();
     let underline = "─".repeat(header_str.len()).truecolor(TITLE_R, TITLE_G, TITLE_B);
-    println!("{}", header_str);
-    println!("{}", underline);
+    println!("{header_str}");
+    println!("{underline}");
 }
 
 pub(crate) fn print_header_error<A: AsRef<str>>(header: A) {
     let header_str = header.as_ref().white().bold();
     let underline = "─".repeat(header_str.len()).truecolor(ERROR_R, ERROR_G, ERROR_B);
-    println!("{}", header_str);
-    println!("{}", underline);
+    println!("{header_str}");
+    println!("{underline}");
 }
 
 fn print_bullet_key<A: AsRef<str>>(key: A) {
     let bullet_str = "- ".truecolor(TITLE_R, TITLE_G, TITLE_B);
     let key_str = key.as_ref().white().bold();
-    println!("{}{}", bullet_str, key_str);
+    println!("{bullet_str}{key_str}");
 }
 
 fn print_bullet<A: AsRef<str>, B: AsRef<str>>(key: A, value: B) {
@@ -135,14 +135,14 @@ fn print_bullet<A: AsRef<str>, B: AsRef<str>>(key: A, value: B) {
     let key_str = key.as_ref().white().bold();
     let value_str = value.as_ref().truecolor(170, 170, 170);
     let colon_str = ": ".truecolor(TITLE_R, TITLE_G, TITLE_B);
-    println!("{}{}{}{}", bullet_str, key_str, colon_str, value_str);
+    println!("{bullet_str}{key_str}{colon_str}{value_str}");
 }
 
 fn print_bullet_parenthetical<A: AsRef<str>, B: AsRef<str>>(key: A, value: B) {
     let bullet_str = "- ".truecolor(TITLE_R, TITLE_G, TITLE_B);
     let key_str = key.as_ref().white().bold();
     let value_str = value.as_ref().truecolor(170, 170, 170);
-    println!("{}{} ({})", bullet_str, key_str, value_str);
+    println!("{bullet_str}{key_str} ({value_str})");
 }
 
 fn print_bullet_indent<A: AsRef<str>, B: AsRef<str>>(key: A, value: B, indent: usize) {
@@ -318,7 +318,7 @@ fn print_chunk<T: Ord + ValueToString>(
 ) {
     if dim_stats.total_values == 1 {
         print_bullet_indent(
-            format!("{}", dim),
+            format!("{dim}"),
             dim_stats.min_value_to_string().unwrap_or("none".to_string()),
             4,
         );
@@ -333,13 +333,13 @@ fn print_chunk<T: Ord + ValueToString>(
                 );
 
                 match align {
-                    Some(true) => text = format!("{} align=yes", text),
-                    Some(false) => text = format!("{} align=no", text),
+                    Some(true) => text = format!("{text} align=yes"),
+                    Some(false) => text = format!("{text} align=no"),
                     None => {}
                 }
 
                 if let Some(reorg_buffer) = reorg_buffer {
-                    text = format!("{} reorg_buffer={}", text, reorg_buffer);
+                    text = format!("{text} reorg_buffer={reorg_buffer}");
                 };
                 print_bullet_indent(dim.plural_name(), text, 4)
             }
@@ -394,7 +394,7 @@ fn print_schema(name: &Datatype, schema: &Table) {
         name.column_types().keys().copied().filter(|x| !schema.has_column(x)).collect::<Vec<_>>();
     let other_columns =
         if other_columns.is_empty() { "[none]".to_string() } else { other_columns.join(", ") };
-    println!("\nother available columns: {}", other_columns);
+    println!("\nother available columns: {other_columns}");
 }
 
 pub(crate) fn print_cryo_conclusion(
@@ -430,7 +430,7 @@ pub(crate) fn print_cryo_conclusion(
             *error_counts.entry(error.to_string()).or_insert(0) += 1;
         }
         for (error, count) in error_counts.iter().take(10) {
-            println!("- {} ({}x)", error, count);
+            println!("- {error} ({count}x)");
         }
         if error_counts.len() > 10 {
             println!("...")
@@ -449,7 +449,7 @@ pub(crate) fn print_cryo_conclusion(
     let seconds = duration.as_secs();
     let millis = duration.subsec_millis();
     let total_time = (seconds as f64) + (duration.subsec_nanos() as f64) / 1e9;
-    let duration_string = format!("{}.{:03} seconds", seconds, millis);
+    let duration_string = format!("{seconds}.{millis:03} seconds");
 
     print_header("collection summary");
     print_bullet("total duration", duration_string);
@@ -580,7 +580,7 @@ fn format_float(number: f64) -> String {
     }
 
     let frac_str =
-        format!("{:0>width$}", frac_part, width = decimal_places).trim_end_matches('0').to_string();
+        format!("{frac_part:0>decimal_places$}").trim_end_matches('0').to_string();
 
     format!("{}.{}", int_part.separate_with_commas(), frac_str)
 }

--- a/crates/freeze/src/types/summaries.rs
+++ b/crates/freeze/src/types/summaries.rs
@@ -579,8 +579,7 @@ fn format_float(number: f64) -> String {
         return format!("{}.0", int_part.separate_with_commas())
     }
 
-    let frac_str =
-        format!("{frac_part:0>decimal_places$}").trim_end_matches('0').to_string();
+    let frac_str = format!("{frac_part:0>decimal_places$}").trim_end_matches('0').to_string();
 
     format!("{}.{}", int_part.separate_with_commas(), frac_str)
 }

--- a/crates/python/rust/collect_adapter.rs
+++ b/crates/python/rust/collect_adapter.rs
@@ -202,25 +202,25 @@ pub fn _collect(
             }
         })
     } else {
-        return Err(PyErr::new::<PyTypeError, _>("must specify datatype or command"))
+        Err(PyErr::new::<PyTypeError, _>("must specify datatype or command"))
     }
 }
 
 async fn run_collect(args: Args) -> PolarsResult<DataFrame> {
     let (query, source, _sink, _env) = match parse_args(&args).await {
         Ok(opts) => opts,
-        Err(e) => panic!("error parsing opts {:?}", e),
+        Err(e) => panic!("error parsing opts {e:?}"),
     };
     match collect(query.into(), source.into()).await {
         Ok(df) => Ok(df),
-        Err(e) => panic!("error collecting {:?}", e),
+        Err(e) => panic!("error collecting {e:?}"),
     }
 }
 
 async fn run_execute(command: String) -> PolarsResult<DataFrame> {
     let args = match cryo_cli::parse_str(command.as_str()).await {
         Ok(opts) => opts,
-        Err(e) => panic!("error parsing opts {:?}", e),
+        Err(e) => panic!("error parsing opts {e:?}"),
     };
     run_collect(args).await
 }

--- a/crates/python/rust/freeze_adapter.rs
+++ b/crates/python/rust/freeze_adapter.rs
@@ -212,7 +212,7 @@ pub fn _freeze(
             }
         })
     } else {
-        return Err(PyErr::new::<PyTypeError, _>("must specify datatypes or command"))
+        Err(PyErr::new::<PyTypeError, _>("must specify datatypes or command"))
     }
 }
 

--- a/crates/to_df/src/lib.rs
+++ b/crates/to_df/src/lib.rs
@@ -209,7 +209,7 @@ pub fn to_df(attrs: TokenStream, input: TokenStream) -> TokenStream {
             let field_name_str = format!("{}", quote!(#name));
             column_types.push(quote! { (#field_name_str, #column_type) });
         } else if name != "n_rows" && name != "event_cols" {
-            println!("invalid column type for {name} in table {}", datatype_str);
+            println!("invalid column type for {name} in table {datatype_str}");
         }
     }
 


### PR DESCRIPTION
## Summary

This PR migrates the codebase from alloy 0.6.4 to alloy 1.0.9, addressing all breaking API changes.

## Changes Made

### 1. Updated alloy version
- Updated from 0.6.4 to 1.0.9 in workspace Cargo.toml

### 2. Provider architecture changes
- Changed from `RootProvider<BoxTransport>` to `DynProvider`
- Used `.erased()` instead of `.boxed()` for provider type erasure
- Updated deprecated methods:
  - `on_http` → `connect_http`
  - `on_ipc` → `connect_ipc`
  - `on_client` → `connect_client`

### 3. Transaction field access
- Changed from `tx.from` to `tx.inner.signer()` to access transaction sender
- Changed from `&tx.inner` to `tx.inner.as_ref()` for pattern matching on transaction envelopes

### 4. Trace API updates
- Removed trace type parameters from method calls
- Now using builder pattern with `.trace_types()` method
- Changed from passing `&Vec<TraceType>` to passing `Vec<TraceType>` by value

### 5. Log decoding changes
- Removed boolean parameter from `decode_log` and `decode_log_parts` methods

### 6. Client creation updates
- Removed type parameters from `RpcClient` (now always boxed)
- Updated deprecated `connect_boxed` to `connect`

### 7. Import fixes
- Added `Provider` trait import where needed for `erased()` method
- Fixed transport-related imports

## Testing

All tests pass after migration. The codebase compiles successfully with no warnings related to the alloy migration.


> This codebase uses a very old alloy version, we want to migrate this to alloy 1.0.9, which has a lot of breaking api changes. The alloy release notes are a useful reference https://github.com/alloy-rs/alloy/releases but also the alloy examples https://github.com/alloy-rs/examples and the book https://alloy.rs/. Try to migrate the dependency and the breaking changes